### PR TITLE
v1.3.8.17 (20/11/2019) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.3.8.17 (20/11/2019)
+- bug fix: refine routine in XChemCootReference.py did not contain argument for covalent bonds
+
 v1.3.8.16 (17/10/2019)
 - added CompoundSMILESproduct field in DB to provide SMILES string of product of covalent binders
 - new function to use phenix.ligandfit and rhofit to fit ligands into initial maps (all enantiomers are tried and best one is selected)

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.3.8.16'
+        xce_object.xce_version = 'v1.3.8.17'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemCootReference.py
+++ b/lib/XChemCootReference.py
@@ -466,7 +466,7 @@ class GUI(object):
                 coot.write_pdb_file(item,os.path.join(self.reference_directory,self.refinementDir,'Refine_'+str(self.Serial),'in.pdb'))
                 break
 
-        self.Refine.RunRefmac(self.Serial,self.RefmacParams,self.external_software,self.xce_logfile)
+        self.Refine.RunRefmac(self.Serial,self.RefmacParams,self.external_software,self.xce_logfile,None)
 #        self.spinnerBox.add(self.refinementRunning)
 #        self.refinementRunning.start()
         self.status_label.set_text('Refinement running...')

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 17/10/2019                                                    #\n'
+            '     # Date: 20/11/2019                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'


### PR DESCRIPTION
- bug fix: refine routine in XChemCootReference.py did not contain argument for covalent bonds