### PR TITLE
v1.3.8.19 (02/12/2019)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.3.8.19 (02/12/2019)
+- bug fix: xce to read resolution at Mn(I)/sig(I) of 2.0 (and 1.5 if possible) from aimless log; now only reads either one or the other. Datasets table now only shows reso at 2.0 since 1.5 not always shown
+
 v1.3.8.18 (25/11/2019)
 - bug fix: added except statement in get_gda_barcodes to catch errors during parsing of multiple visits
 
@@ -99,20 +102,4 @@ v1.3.3 (19/02/2019)
 - bug fix: removed not supported 'group leader' and 'investigator' option from edit deposition data menu
 
 v1.3.2 (12/02/2019)
-- bug fix: removed reference to non-existent labels (prevented opening of pandda models/ maps)
-
-v1.3.1 (25/01/2019)
-- bug fix: support of new autoProc directory structure at DLS
-- bug fix: removal of non-existent DataProcessingProgram entries at DLS from collectionTable
-- bug fix: xce coot plugin: changed layout so that full window can be displayed on any screen
-
-v1.3 (16/01/2019)
-- bug fix: get space group from aimless log file if file contains output from other programs like unique
-- bug fix: change qsub command for dimple and restraints generation so that it works outside DLS
-- new feature: assign labels to datasets in xce-coot interface
-- bug fix: accomodate None value when querying DB for event map information
-- new feature: preparation of apo mmcif files containing SF's all all datasets used for pandda.analyse
-- improvement: refinement of pandda models enabled where ligand binding did not lead to any differences between bound-state and ground-state
-- bug fix: update data_rxxxxsf field in apo mmcif file
-- fix pandda button in settings tab
-- add XCE manual to help menu 
+- bug fix: removed reference to non-existent labels (prevented opening of 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,6 @@
 v1.3.8.19 (02/12/2019)
 - bug fix: xce to read resolution at Mn(I)/sig(I) of 2.0 (and 1.5 if possible) from aimless log; now only reads either one or the other. Datasets table now only shows reso at 2.0 since 1.5 not always shown
+- bug fix: read gda barcodes into DB and display in datasets table
 
 v1.3.8.18 (25/11/2019)
 - bug fix: added except statement in get_gda_barcodes to catch errors during parsing of multiple visits

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -3810,7 +3810,7 @@ class XChemExplorer(QtGui.QApplication):
 
         column_name = ['Program',
                        'Resolution\nOverall',
-                       'Resolution\n[Mn<I/sig(I)> = 1.5]',
+                       'Resolution\n[Mn<I/sig(I)> = 2.0]',
                        'DataProcessing\nSpaceGroup',
                        'Mn<I/sig(I)>\nHigh',
                        'Rmerge\nLow',

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.3.8.18'
+        xce_object.xce_version = 'v1.3.8.19'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -301,7 +301,7 @@ class setup():
         #                                            - appears in create_widgets_for_autoprocessing_results_only()
 
         xce_object.datasets_summary_table_columns = ['Sample ID',
-                                                     'Resolution\n[Mn<I/sig(I)> = 1.5]',
+                                                     'Resolution\n[Mn<I/sig(I)> = 2.0]',
                                                      'DataProcessing\nSpaceGroup',
                                                      'DataProcessing\nRfree',
                                                      'SoakDB\nBarcode',

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -748,6 +748,7 @@ class data_source:
         connect.commit()
 
     def update_data_source(self,sampleID,data_dict):
+        print 'here'
         data_dict['LastUpdated']=str(datetime.now().strftime("%Y-%m-%d %H:%M"))
         data_dict['LastUpdated_by']=getpass.getuser()
 
@@ -766,7 +767,9 @@ class data_source:
         cursor = connect.cursor()
         update_string=''
         for key in data_dict:
+            print key
             value=data_dict[key]
+            print value
             if key=='ID' or key=='CrystalName':
                 continue
             if not str(value).replace(' ','')=='':  # ignore empty fields
@@ -777,6 +780,7 @@ class data_source:
             print "UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'"
             cursor.execute("UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'")
             connect.commit()
+        quit()
 
     def update_panddaTable(self,sampleID,site_index,data_dict):
         data_dict['LastUpdated']=str(datetime.now().strftime("%Y-%m-%d %H:%M"))

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -774,7 +774,7 @@ class data_source:
             else:
                 update_string+=str(key)+' = null,'
         if update_string != '':
-#            print "UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'"
+            print "UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'"
             cursor.execute("UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'")
             connect.commit()
 

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -767,9 +767,7 @@ class data_source:
         cursor = connect.cursor()
         update_string=''
         for key in data_dict:
-            print key
             value=data_dict[key]
-            print value
             if key=='ID' or key=='CrystalName':
                 continue
             if not str(value).replace(' ','')=='':  # ignore empty fields
@@ -777,10 +775,9 @@ class data_source:
             else:
                 update_string+=str(key)+' = null,'
         if update_string != '':
-            print "UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'"
+#            print "UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'"
             cursor.execute("UPDATE mainTable SET "+update_string[:-1]+" WHERE CrystalName="+"'"+sampleID+"'")
             connect.commit()
-        quit()
 
     def update_panddaTable(self,sampleID,site_index,data_dict):
         data_dict['LastUpdated']=str(datetime.now().strftime("%Y-%m-%d %H:%M"))

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 25/11/2019                                                    #\n'
+            '     # Date: 02/12/2019                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -2181,7 +2181,7 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
             dbDict = {}
             dbDict['DataCollectionPinBarcode'] = pinDict[sample]
 #            self.db.update_data_source(sample,dbDict)
-            self.db.update_specified_table(sample,dbDict,'collectionTable'):
+            self.db.update_specified_table(sample,dbDict,'collectionTable')
 
 
 class choose_autoprocessing_outcome(QtCore.QThread):

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -2177,10 +2177,10 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
 
     def update_database(self,pinDict):
         self.Logfile.insert('updating database with pinDIs from GDA logfiles')
-        print pinDict
-        quit()
         for sample in pinDict:
-            dbDict = {'DataCollectionPinBarcode': pinDict[sample]}
+            dbDict = {}
+            dbDict['DataCollectionPinBarcode'] = pinDict[sample]
+            print sample,dbDict
             self.db.update_data_source(sample,dbDict)
 
 

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -2180,8 +2180,8 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
         for sample in pinDict:
             dbDict = {}
             dbDict['DataCollectionPinBarcode'] = pinDict[sample]
-            self.db.update_data_source(sample,dbDict)
-
+#            self.db.update_data_source(sample,dbDict)
+            self.db.update_specified_table(sample,dbDict,'collectionTable'):
 
 
 class choose_autoprocessing_outcome(QtCore.QThread):

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -2181,7 +2181,7 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
             dbDict = {}
             dbDict['DataCollectionPinBarcode'] = pinDict[sample]
 #            self.db.update_data_source(sample,dbDict)
-#            self.db.update_specified_table(sample,dbDict,'collectionTable')
+            self.db.update_specified_table(sample,dbDict,'collectionTable')
 
 
 class choose_autoprocessing_outcome(QtCore.QThread):

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -1152,7 +1152,7 @@ class run_dimple_on_all_autoprocessing_files(QtCore.QThread):
         db=XChemDB.data_source(os.path.join(self.database_directory,self.data_source_file))
         database=os.path.join(self.database_directory,self.data_source_file)
 
-        print(self.sample_list)
+#        print(self.sample_list)
 
         for n,item in enumerate(self.sample_list):
 
@@ -2150,7 +2150,7 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
         self.xce_logfile = xce_logfile
         self.Logfile = XChemLog.updateLog(xce_logfile)
 
-        self.db = XChemDB.data_source(os.path.join(database))
+        self.db = XChemDB.data_source(database)
         self.allSamples = self.db.collected_xtals_during_visit_for_scoring(visit)
 
         self.gdaLogInstructions = gdaLogInstructions
@@ -2217,7 +2217,7 @@ class choose_autoprocessing_outcome(QtCore.QThread):
                     self.allSamples.append(e)
         else:
             self.allSamples = self.db.collected_xtals_during_visit_for_scoring(visit)
-        print 'here', self.allSamples
+#        print 'here', self.allSamples
 #        self.allSamples = self.db.collected_xtals_during_visit_for_scoring(visit,rescore)
 
 
@@ -2405,13 +2405,13 @@ class read_write_autoprocessing_results_from_to_disc(QtCore.QThread):
 #        self.target = target
         self.processedDir =  processedDir
         self.visit,self.beamline = XChemMain.getVisitAndBeamline(self.processedDir)
-        print 'visit'
+#        print 'visit'
         self.projectDir = projectDir
         self.Logfile = XChemLog.updateLog(xce_logfile)
         self.target = target
         self.agamemnon = agamemnon
         if self.agamemnon:
-            print 'procDir',self.processedDir
+#            print 'procDir',self.processedDir
 #            if len(procDir.split('/')) >= 8:
 #                if procDir.split('/')[7] == 'agamemnon'
 #            quit()

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -2181,7 +2181,7 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
             dbDict = {}
             dbDict['DataCollectionPinBarcode'] = pinDict[sample]
 #            self.db.update_data_source(sample,dbDict)
-            self.db.update_specified_table(sample,dbDict,'collectionTable')
+#            self.db.update_specified_table(sample,dbDict,'collectionTable')
 
 
 class choose_autoprocessing_outcome(QtCore.QThread):

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -2177,6 +2177,8 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
 
     def update_database(self,pinDict):
         self.Logfile.insert('updating database with pinDIs from GDA logfiles')
+        print pinDict
+        quit()
         for sample in pinDict:
             dbDict = {'DataCollectionPinBarcode': pinDict[sample]}
             self.db.update_data_source(sample,dbDict)

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -2180,7 +2180,6 @@ class read_pinIDs_from_gda_logs(QtCore.QThread):
         for sample in pinDict:
             dbDict = {}
             dbDict['DataCollectionPinBarcode'] = pinDict[sample]
-            print sample,dbDict
             self.db.update_data_source(sample,dbDict)
 
 

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -588,6 +588,10 @@ class parse:
         except IndexError:
             pass
 
+        resolution_at_15_sigma_line_overall_found=False
+        resolution_at_20_sigma_line_overall_found=False
+
+
 #
 #        print '=====>',self.aimless['DataCollectionRun'],logfile
 #

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -641,15 +641,18 @@ class parse:
                 self.aimless['DataProcessingCChalfLow'] = line.split()[2]
                 self.aimless['DataProcessingCChalfHigh'] = line.split()[3]
             if line.startswith('Estimates of resolution limits: overall'):
-                resolution_at_sigma_line_overall_found=True
-            if resolution_at_sigma_line_overall_found:
+                resolution_at_15_sigma_line_overall_found=True
+                resolution_at_20_sigma_line_overall_found=True
+            if resolution_at_15_sigma_line_overall_found:
                 if 'from Mn(I/sd)' in line and len(line.split()) >= 7:
                     if '1.5' in line.split()[3]:
                         self.aimless['DataProcessingResolutionHigh15sigma']=line.split()[6][:-1]
-                        resolution_at_sigma_line_overall_found=False
+                        resolution_at_15_sigma_line_overall_found=False
+            if resolution_at_20_sigma_line_overall_found:
+                if 'from Mn(I/sd)' in line and len(line.split()) >= 7:
                     if '2.0' in line.split()[3]:
                         self.aimless['DataProcessingResolutionHigh20sigma']=line.split()[6][:-1]
-                        resolution_at_sigma_line_overall_found=False
+                        resolution_at_20_sigma_line_overall_found=False
             if (line.startswith('Average unit cell:') or line.startswith('  Unit cell parameters')) and len(line.split())==9:
                 tmp = [line.split()]
                 a = int(float(tmp[0][3]))


### PR DESCRIPTION
- bug fix: xce to read resolution at Mn(I)/sig(I) of 2.0 (and 1.5 if possible) from aimless log; now only reads either one or the other. Datasets table now only shows reso at 2.0 since 1.5 not always shown
- bug fix: read gda barcodes into DB and display in datasets table
