### PR TITLE
v1.4.1 (16/12/2019)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,8 @@
+v1.4.1 (16/12/2019)
+- bug fix: in helpers/assign_stereochemistry.py; use CompoundSMILES instead of CompoundSMILESproduct (which need to be provided by user)
+- bug fix: auto-fitting of ligands - use default ccp4 distribition and submission command
+- bug fix: add 'module load mx' to restraints generation script; uses default ccp4 installation, otherwise CLIB path for GRADE broken
+
 v1.4.0 (03/12/2019)
 - introduced simple semantic versioning according to https://semver.org
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.4.0'
+        xce_object.xce_version = 'v1.4.1'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/helpers/assign_stereochemistry.py
+++ b/helpers/assign_stereochemistry.py
@@ -12,6 +12,7 @@ def enumerateStereoChem(compoundID,sampleDir,db,xtal):
     # this is because funny things happen to aromatic rings in case the file was made with GRADE
     os.chdir(os.path.join(sampleDir,'compound'))
     sql = "select CompoundSMILESproduct from mainTable where CrystalName = '%s'" % xtal
+    print 'sqlite query:',sql
     query = db.execute_statement(sql)
     originalSMILES = query[0][0]
     print originalSMILES
@@ -71,7 +72,9 @@ if __name__=='__main__':
     compoundID = sys.argv[1]
     sampleDir = sys.argv[2]
     xtal = sampleDir[sampleDir.rfind('/')+1:]
+    print 'sampleID:',xtal
     database = sys.argv[3]
+    print 'database:',database
     db=XChemDB.data_source(database)
     enumerateStereoChem(compoundID,sampleDir,db,xtal)
 

--- a/helpers/assign_stereochemistry.py
+++ b/helpers/assign_stereochemistry.py
@@ -11,7 +11,7 @@ def enumerateStereoChem(compoundID,sampleDir,db,xtal):
     # which program was used to create the initial restrains
     # this is because funny things happen to aromatic rings in case the file was made with GRADE
     os.chdir(os.path.join(sampleDir,'compound'))
-    sql = "select CompoundSMILESproduct from mainTable where CrystalName = '%s'" % xtal
+    sql = "select CompoundSMILES from mainTable where CrystalName = '%s'" % xtal
     print 'sqlite query:',sql
     query = db.execute_statement(sql)
     originalSMILES = query[0][0]

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 03/12/2019                                                    #\n'
+            '     # Date: 16/12/2019                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -930,6 +930,10 @@ class fit_ligands(QtCore.QThread):
         else:
             top_line = '#!' + os.getenv('SHELL') + '\n'
 
+        module = ''
+        if os.path.isdir('/dls'):
+            module = 'module load mx\n'
+
         cmd = (
             '{0!s}\n'.format(top_line)+
             '\n'
@@ -937,6 +941,7 @@ class fit_ligands(QtCore.QThread):
             '\n'
             'cd %s\n' %os.path.join(self.initial_model_directory,sampleID,'autofit_ligand') +
             '\n'
+            + module
         )
 
         return cmd

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -267,6 +267,10 @@ class helpers:
 
         strip_hydrogens = 'phenix.reduce {0!s}.pdb -trim > {0!s}_tmp.pdb'.format(compoundID.replace(' ', ''))
 
+        module = ''
+        if os.path.isdir('/dls'):
+            module = 'module load mx\n'
+
         Cmds = (
 
             header +
@@ -274,6 +278,8 @@ class helpers:
             'export XChemExplorer_DIR="' + os.getenv('XChemExplorer_DIR') + '"' +
             '\n'
             'source $XChemExplorer_DIR/setup-scripts/xce.setup-sh'
+            '\n'
+            + module +
             '\n'
             '$CCP4/bin/ccp4-python $XChemExplorer_DIR/helpers/update_status_flag.py {0!s} {1!s} {2!s} {3!s}'
             .format(os.path.join(database_directory, data_source_file), sample, 'RefinementCIFStatus', 'running') +


### PR DESCRIPTION
- bug fix: in helpers/assign_stereochemistry.py; use CompoundSMILES instead of CompoundSMILESproduct (which need to be provided by user)
- bug fix: auto-fitting of ligands - use default ccp4 distribition and submission command
- bug fix: add 'module load mx' to restraints generation script; uses default ccp4 installation, otherwise CLIB path for GRADE broken
