### PR TITLE
v1.4.8 (07/02/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.4.8 (07/02/2020)
+- bug fix: default labxchem folders are only selected if xce starts in /dls/labxchem/...; just having labxchem in current directory string is not sufficient
+
 v1.4.7 (07/02/2020)
 - added script to helpers which can replace residues in bound and ground state based on a new reference model (change_residues_in_ground_and_bound-state.py); cannot be called from GUI at the moment
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.4.7'
+        xce_object.xce_version = 'v1.4.8'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12
@@ -46,7 +46,8 @@ class setup():
         xce_object.xce_logfile = os.path.join(xce_object.current_directory, 'xce.log')
 
         # if in the correct place, set the various directories
-        if 'labxchem' in xce_object.current_directory:
+        if xce_object.current_directory.startswith('/dls/labxchem'):
+#        if 'labxchem' in xce_object.current_directory:
             if len(xce_object.current_directory.split('/')) >= 9 and xce_object.current_directory.split('/')[6] == 'processing' and xce_object.current_directory.split('/')[8] == 'processing':
                 xce_object.labxchem_directory = '/' + os.path.join(
                         *xce_object.current_directory.split('/')[1:8])  # need splat operator: *
@@ -70,8 +71,11 @@ class setup():
             xce_object.database_directory = os.path.join(xce_object.labxchem_directory, 'processing', 'database')
             xce_object.panddas_directory = os.path.join(xce_object.labxchem_directory, 'processing', 'analysis',
                                                         'panddas')
-            xce_object.datasets_summary_file = os.path.join(xce_object.database_directory,
-                                                            str(os.getcwd().split('/')[5]) + '_summary.pkl')
+
+
+            xce_object.datasets_summary_file = None
+#            xce_object.datasets_summary_file = os.path.join(xce_object.database_directory,
+#                                                            str(os.getcwd().split('/')[5]) + '_summary.pkl')
             xce_object.data_source_file = ''
             xce_object.html_export_directory = os.path.join(xce_object.labxchem_directory, 'processing', 'html')
             xce_object.group_deposit_directory = os.path.join(xce_object.labxchem_directory, 'processing',


### PR DESCRIPTION
- bug fix: default labxchem folders are only selected if xce starts in /dls/labxchem/...; just having labxchem in current directory string is not sufficient