### PR TITLE
v1.4.9 (13/02/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.4.9 (20/02/2020)
+- bug fix: corrected DataProcessingUnitCellVolume calculation from merging-statistics.json file for trigonal lattice
+
 v1.4.8 (07/02/2020)
 - bug fix: default labxchem folders are only selected if xce starts in /dls/labxchem/...; just having labxchem in current directory string is not sufficient
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,6 @@
 v1.4.9 (20/02/2020)
 - bug fix: corrected DataProcessingUnitCellVolume calculation from merging-statistics.json file for trigonal lattice
+- show only 'resolution high' in tables because formatting for resolution at 1.5 or 2.0 I/sig(I) inconsistent in aimless logfiles and not reported in dials scaling logile
 
 v1.4.8 (07/02/2020)
 - bug fix: default labxchem folders are only selected if xce starts in /dls/labxchem/...; just having labxchem in current directory string is not sufficient

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,4 @@
-v1.4.9 (20/02/2020)
+v1.4.9 (13/02/2020)
 - bug fix: corrected DataProcessingUnitCellVolume calculation from merging-statistics.json file for trigonal lattice
 - show only 'resolution high' in tables because formatting for resolution at 1.5 or 2.0 I/sig(I) inconsistent in aimless logfiles and not reported in dials scaling logile
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.4.8'
+        xce_object.xce_version = 'v1.4.9'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12
@@ -305,7 +305,8 @@ class setup():
         #                                            - appears in create_widgets_for_autoprocessing_results_only()
 
         xce_object.datasets_summary_table_columns = ['Sample ID',
-                                                     'Resolution\n[Mn<I/sig(I)> = 2.0]',
+#                                                     'Resolution\n[Mn<I/sig(I)> = 2.0]',
+                                                     'Resolution\nHigh',
                                                      'DataProcessing\nSpaceGroup',
                                                      'DataProcessing\nRfree',
                                                      'SoakDB\nBarcode',
@@ -349,7 +350,8 @@ class setup():
         xce_object.datasets_reprocess_columns = ['Dataset ID',
                                                  'Sample ID',
                                                  'Run\nxia2',
-                                                 'Resolution\n[Mn<I/sig(I)> = 1.5]',
+#                                                 'Resolution\n[Mn<I/sig(I)> = 1.5]',
+                                                 'Resolution\nHigh',
                                                  'Rmerge\nLow',
                                                  'Dimple\nRfree',
                                                  'DataProcessing\nSpaceGroup',
@@ -364,7 +366,8 @@ class setup():
                                          'Select',
                                          'Compound ID',
                                          'Smiles',
-                                         'Resolution\n[Mn<I/sig(I)> = 1.5]',
+#                                         'Resolution\n[Mn<I/sig(I)> = 1.5]',
+                                         'Resolution\nHigh',
                                          'Dimple\nRcryst',
                                          'Dimple\nRfree',
                                          'DataProcessing\nSpaceGroup',

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 07/02/2020                                                    #\n'
+            '     # Date: 13/02/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -808,10 +808,8 @@ class parse:
 
     def read_mmcif(self,mmcif):
         for line in open(mmcif):
-            print '=>', line
             if line.startswith('_cell.angle_alpha '):
                 self.aimless['DataProcessingAlpha'] = line.split()[1]
-                print '--------->',line
             elif line.startswith('_cell.angle_beta '):
                 self.aimless['DataProcessingBeta'] = line.split()[1]
             elif line.startswith('_cell.angle_gamma '):
@@ -835,6 +833,9 @@ class parse:
                     'DataProcessingA'] + ' ' + self.aimless['DataProcessingA'] + ' ' + self.aimless[
                                                              'DataProcessingA'] + ' ' + self.aimless[
                                                              'DataProcessingA'] + ' ' + self.aimless['DataProcessingA']
+        print '=================================='
+        print self.aimless
+        print '=================================='
 
 
     def get_lattice_from_space_group(self,logfile_spacegroup):

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -808,8 +808,10 @@ class parse:
 
     def read_mmcif(self,mmcif):
         for line in open(mmcif):
+            print '=>', line
             if line.startswith('_cell.angle_alpha '):
                 self.aimless['DataProcessingAlpha'] = line.split()[1]
+                print '--------->',line
             elif line.startswith('_cell.angle_beta '):
                 self.aimless['DataProcessingBeta'] = line.split()[1]
             elif line.startswith('_cell.angle_gamma '):

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -828,7 +828,8 @@ class parse:
                     self.aimless['DataProcessingSpaceGroup'])
             elif line.startswith('_space_group.crystal_system'):
                 self.aimless['DataProcessingLattice'] = line.split()[1]
-
+                if self.aimless['DataProcessingLattice'] == 'trigonal':
+                    self.aimless['DataProcessingLattice'] = 'hexagonal'
             self.aimless['DataProcessingUnitCell'] = self.aimless['DataProcessingA'] + ' ' + self.aimless[
                     'DataProcessingA'] + ' ' + self.aimless['DataProcessingA'] + ' ' + self.aimless[
                                                              'DataProcessingA'] + ' ' + self.aimless[
@@ -865,6 +866,7 @@ class parse:
             unitcell_volume=a*b*c* \
                             math.sqrt((1-math.cos(alpha)**2-math.cos(beta)**2-math.cos(gamma)**2) \
                                       +2*(math.cos(alpha)*math.cos(beta)*math.cos(gamma)))
+            print 'unit cell volume',unitcell_volume
 #        if lattice=='monoclinic':
         if 'monoclinic' in lattice:
             unitcell_volume=round(a*b*c*math.sin(beta),1)

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -834,10 +834,6 @@ class parse:
                     'DataProcessingA'] + ' ' + self.aimless['DataProcessingA'] + ' ' + self.aimless[
                                                              'DataProcessingA'] + ' ' + self.aimless[
                                                              'DataProcessingA'] + ' ' + self.aimless['DataProcessingA']
-        print '=================================='
-        print self.aimless
-        print '=================================='
-
 
     def get_lattice_from_space_group(self,logfile_spacegroup):
         lattice_type='n/a'


### PR DESCRIPTION
- bug fix: corrected DataProcessingUnitCellVolume calculation from merging-statistics.json file for trigonal lattice
- show only 'resolution high' in tables because formatting for resolution at 1.5 or 2.0 I/sig(I) inconsistent in aimless logfiles and not reported in dials scaling logile
