### PR TITLE
v1.5.0 (20/02/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.5.0 (20/02/2020)
+- ground-state mean maps are EXCLUDED from apo deposition, because either map2mtz conversion was faulty or columns were missing; moreover, they are not required to reproduce the maps and users can deposit them separately on ZENODO if they want
+
 v1.4.10 (18/02/2020)
 - XChemDeposit: remove _pdbx_related_exp_data_set block because PanDDA ZENODO upload is not required
 - XChemDeposit: add _pdbx_contact_author.identifier_ORCID field

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1038,10 +1038,10 @@ class XChemExplorer(QtGui.QApplication):
         start_thread = True
         self.update_log.insert('preparing mmcif files for PDB group deposition...')
         ignore_event_map = False
-        if structureType == 'ground-state':
+        if structureType == 'ground_state':
             try:
                 self.update_log.insert('ground-state deposition')
-                data_template_dict = self.db.get_deposit_dict_for_sample('ground-state')
+                data_template_dict = self.db.get_deposit_dict_for_sample('ground_state')
                 print data_template_dict
                 pdb = data_template_dict['PDB_file']
                 self.update_log.insert('looking for ground-state PDB: ' + pdb)

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1039,22 +1039,25 @@ class XChemExplorer(QtGui.QApplication):
         self.update_log.insert('preparing mmcif files for PDB group deposition...')
         ignore_event_map = False
         if structureType == 'ground-state':
-            self.update_log.insert('ground-state deposition')
-            data_template_dict = self.db.get_deposit_dict_for_sample('ground-state')
-            print data_template_dict
-            pdb = data_template_dict['PDB_file']
-            self.update_log.insert('looking for ground-state PDB: ' + pdb)
-            if not os.path.isfile(pdb):
-                self.update_log.error('ground-state PDB does not exist; stopping...')
-                start_thread = False
-            mtz = data_template_dict['MTZ_file']
-            self.update_log.insert('looking for ground-state MTZ: ' + mtz)
-            if not os.path.isfile(mtz):
-                self.update_log.error('ground-state MTZ does not exist; stopping...')
-                start_thread = False
-            ground_state = [ pdb,
-                             mtz,
-                             self.panddas_directory ]
+            try:
+                self.update_log.insert('ground-state deposition')
+                data_template_dict = self.db.get_deposit_dict_for_sample('ground-state')
+                print data_template_dict
+                pdb = data_template_dict['PDB_file']
+                self.update_log.insert('looking for ground-state PDB: ' + pdb)
+                if not os.path.isfile(pdb):
+                    self.update_log.error('ground-state PDB does not exist; stopping...')
+                    start_thread = False
+                mtz = data_template_dict['MTZ_file']
+                self.update_log.insert('looking for ground-state MTZ: ' + mtz)
+                if not os.path.isfile(mtz):
+                    self.update_log.error('ground-state MTZ does not exist; stopping...')
+                    start_thread = False
+                ground_state = [ pdb,
+                                 mtz,
+                                 self.panddas_directory ]
+            except KeyError:
+                self.update_log.error('seems like there is no entry for ground-state in database')
         else:
             ground_state = []
             if self.deposition_bounnd_state_preparation_ignore_event_map.isChecked():

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1041,6 +1041,7 @@ class XChemExplorer(QtGui.QApplication):
         if structureType == 'ground-state':
             self.update_log.insert('ground-state deposition')
             data_template_dict = self.db.get_deposit_dict_for_sample('ground-state')
+            print data_template_dict
             pdb = data_template_dict['PDB_file']
             self.update_log.insert('looking for ground-state PDB: ' + pdb)
             if not os.path.isfile(pdb):

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1067,6 +1067,10 @@ class XChemExplorer(QtGui.QApplication):
 #        structureType = "ligand_bound"
 
         if start_thread:
+            if ground_state != []:
+                self.update_log.insert('apo PDB: ' + ground_state[0])
+                self.update_log.insert('apo MTZ: ' + ground_state[1])
+                self.update_log.insert('pandda directory: ' + ground_state[2])
             overwrite_existing_mmcif = True
             self.work_thread = XChemDeposit.prepare_mmcif_files_for_deposition(
                 os.path.join(self.database_directory, self.data_source_file),

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1058,6 +1058,7 @@ class XChemExplorer(QtGui.QApplication):
                                  self.panddas_directory ]
             except KeyError:
                 self.update_log.error('seems like there is no entry for ground-state in database')
+                pass
         else:
             ground_state = []
             if self.deposition_bounnd_state_preparation_ignore_event_map.isChecked():

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -599,7 +599,7 @@ class XChemExplorer(QtGui.QApplication):
 
     def prepare_ground_state_mmcif(self):
         self.update_log.insert('preparing mmcif file for apo structure deposition')
-        self.prepare_models_for_deposition_ligand_bound('ground-state')
+        self.prepare_models_for_deposition_ligand_bound('ground_state')
 
     def open_icm(self):
         self.update_log.insert('starting ICM...')

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1042,10 +1042,12 @@ class XChemExplorer(QtGui.QApplication):
             self.update_log.insert('ground-state deposition')
             data_template_dict = self.db.get_deposit_dict_for_sample('ground-state')
             pdb = data_template_dict['PDB_file']
+            self.update_log.insert('looking for ground-state PDB: ' + pdb)
             if not os.path.isfile(pdb):
                 self.update_log.error('ground-state PDB does not exist; stopping...')
                 start_thread = False
             mtz = data_template_dict['MTZ_file']
+            self.update_log.insert('looking for ground-state MTZ: ' + mtz)
             if not os.path.isfile(mtz):
                 self.update_log.error('ground-state MTZ does not exist; stopping...')
                 start_thread = False

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1042,7 +1042,6 @@ class XChemExplorer(QtGui.QApplication):
             try:
                 self.update_log.insert('ground-state deposition')
                 data_template_dict = self.db.get_deposit_dict_for_sample('ground_state')
-                print data_template_dict
                 pdb = data_template_dict['PDB_file']
                 self.update_log.insert('looking for ground-state PDB: ' + pdb)
                 if not os.path.isfile(pdb):

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -1058,7 +1058,7 @@ class XChemExplorer(QtGui.QApplication):
                                  self.panddas_directory ]
             except KeyError:
                 self.update_log.error('seems like there is no entry for ground-state in database')
-                pass
+                start_thread = False
         else:
             ground_state = []
             if self.deposition_bounnd_state_preparation_ignore_event_map.isChecked():

--- a/gui_scripts/deposition_tab.py
+++ b/gui_scripts/deposition_tab.py
@@ -82,6 +82,7 @@ class DepositionTab():
         deposition_ground_state_heading = self.layout_funcs.add_depo_heading('Group deposition of ground-state model')
         deposition_ground_state_heading.setStyleSheet("font: bold 20pt Arial")
 
+        deposition_ground_state_preparation_step_one_text = self.layout_funcs.add_depo_text(XChemToolTips.notification_about_changes_to_apo_deposition())
 
 
         deposition_ground_state_prerequisites = self.layout_funcs.add_depo_heading('Prerequisites')
@@ -92,23 +93,23 @@ class DepositionTab():
         deposition_ground_state_preparation = self.layout_funcs.add_depo_heading('Procedure')
         deposition_ground_state_preparation.setStyleSheet("font: italic bold 17pt Arial ")
 
-        deposition_ground_state_preparation_step_one_text = self.layout_funcs.add_depo_text(XChemToolTips.deposition_ground_state_preparation_step_one_text())
+#        deposition_ground_state_preparation_step_one_text = self.layout_funcs.add_depo_text(XChemToolTips.deposition_ground_state_preparation_step_one_text())
 
-        ground_state_pdb_button = QtGui.QPushButton('Select PDB file')
-        ground_state_pdb_button.clicked.connect(xce_object.select_ground_state_pdb)
-        ground_state_pdb_button.setMaximumWidth(200)
-        xce_object.ground_state_pdb_button_label = QtGui.QLabel('')
-        xce_object.ground_state_pdb_button_label.setStyleSheet('color: blue')
-
-        deposition_ground_state_log_info = self.layout_funcs.add_depo_text(XChemToolTips.deposition_ground_state_log_info())
-
-        deposition_ground_state_preparation_step_two_text = self.layout_funcs.add_depo_text(XChemToolTips.deposition_ground_state_preparation_step_two_text())
-
-        ground_state_mtz_button = QtGui.QPushButton('Select MTZ file')
-        ground_state_mtz_button.clicked.connect(xce_object.select_ground_state_mtz)
-        ground_state_mtz_button.setMaximumWidth(200)
-        xce_object.ground_state_mtz_button_label = QtGui.QLabel('')
-        xce_object.ground_state_mtz_button_label.setStyleSheet('color: blue')
+#        ground_state_pdb_button = QtGui.QPushButton('Select PDB file')
+#        ground_state_pdb_button.clicked.connect(xce_object.select_ground_state_pdb)
+#        ground_state_pdb_button.setMaximumWidth(200)
+#        xce_object.ground_state_pdb_button_label = QtGui.QLabel('')
+#        xce_object.ground_state_pdb_button_label.setStyleSheet('color: blue')
+#
+#        deposition_ground_state_log_info = self.layout_funcs.add_depo_text(XChemToolTips.deposition_ground_state_log_info())
+#
+#        deposition_ground_state_preparation_step_two_text = self.layout_funcs.add_depo_text(XChemToolTips.deposition_ground_state_preparation_step_two_text())
+#
+#        ground_state_mtz_button = QtGui.QPushButton('Select MTZ file')
+#        ground_state_mtz_button.clicked.connect(xce_object.select_ground_state_mtz)
+#        ground_state_mtz_button.setMaximumWidth(200)
+#        xce_object.ground_state_mtz_button_label = QtGui.QLabel('')
+#        xce_object.ground_state_mtz_button_label.setStyleSheet('color: blue')
 
         deposition_ground_state_preparation_step_three_text = self.layout_funcs.add_depo_text(XChemToolTips.deposition_ground_state_preparation_step_three_text())
         xce_object.ground_state_pandda_directory_label = QtGui.QLabel(xce_object.panddas_directory)
@@ -192,14 +193,14 @@ class DepositionTab():
                                   QtGui.QLabel(' \n\n\n '),
 
                                   deposition_ground_state_heading, QtGui.QLabel(' \n '),
+                                  deposition_ground_state_preparation_step_one_text, QtGui.QLabel(' \n '),
                                   deposition_ground_state_prerequisites,
                                   deposition_ground_state_prerequisites_text, QtGui.QLabel(' \n '),
                                   deposition_ground_state_preparation,
-                                  deposition_ground_state_preparation_step_one_text,
-                                  ground_state_pdb_button, xce_object.ground_state_pdb_button_label,
-                                  deposition_ground_state_log_info,
-                                  deposition_ground_state_preparation_step_two_text,
-                                  ground_state_mtz_button,xce_object.ground_state_mtz_button_label,
+#                                  ground_state_pdb_button, xce_object.ground_state_pdb_button_label,
+#                                  deposition_ground_state_log_info,
+#                                  deposition_ground_state_preparation_step_two_text,
+#                                  ground_state_mtz_button,xce_object.ground_state_mtz_button_label,
                                   deposition_ground_state_preparation_step_three_text,
                                   xce_object.ground_state_pandda_directory_label,
                                   deposition_ground_state_preparation_step_four_text,

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.4.10'
+        xce_object.xce_version = 'v1.5.0'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -628,11 +628,11 @@ class data_source:
         data=[]
         connect=sqlite3.connect(self.data_source_file)     # creates sqlite file if non existent
         cursor = connect.cursor()
-        if sampleID == 'ground-state':      # just select first row in depositTable
-            cursor.execute("SELECT * FROM depositTable ORDER BY ROWID ASC LIMIT 1;")
-        else:
-            cursor.execute("select * from depositTable where CrystalName='{0!s}';".format(sampleID))
-
+#        if sampleID == 'ground-state':      # just select first row in depositTable
+#            cursor.execute("SELECT * FROM depositTable ORDER BY ROWID ASC LIMIT 1;")
+#        else:
+#            cursor.execute("select * from depositTable where CrystalName='{0!s}';".format(sampleID))
+        cursor.execute("select * from depositTable where CrystalName='{0!s}';".format(sampleID))
         for column in cursor.description:
             header.append(column[0])
         data = cursor.fetchall()

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -1617,6 +1617,9 @@ class data_source:
                 Logfile.insert('entry for ground-state model in depositTable does not exist')
             else:
                 Logfile.warning('entry for ground-state model in depositTable does already exist')
+                Logfile.warning('updating PDB, MTZ and DimplePANDDApath for ground-state entry')
+                cursor.execute("update depositTable set PDB_file='%s' MTZ_file='%s' DimplePANDDApath='%s' where StructureType='ground_state'" %(db_dict['PDB_file'],db_dict['MTZ_file'],db_dict['DimplePANDDApath']))
+                connect.commit()
                 return
 
         cursor.execute("select CrystalName,StructureType from depositTable where CrystalName is '{0!s}' and StructureType is '{1!s}'".format(xtal, type))

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -1618,7 +1618,7 @@ class data_source:
             else:
                 Logfile.warning('entry for ground-state model in depositTable does already exist')
                 Logfile.warning('updating PDB, MTZ and DimplePANDDApath for ground-state entry')
-                cursor.execute("update depositTable set PDB_file='%s' MTZ_file='%s' DimplePANDDApath='%s' where StructureType='ground_state'" %(db_dict['PDB_file'],db_dict['MTZ_file'],db_dict['DimplePANDDApath']))
+                cursor.execute("update depositTable set PDB_file='%s', MTZ_file='%s', DimplePANDDApath='%s' where StructureType='ground_state'" %(db_dict['PDB_file'],db_dict['MTZ_file'],db_dict['DimplePANDDApath']))
                 connect.commit()
                 return
 

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -406,6 +406,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
             self.panddaDir = ground_state[2]
             self.projectDir = self.panddaDir
             self.pdb = pdbtools(self.ground_state_pdb)
+            self.mtz = mtztools(self.ground_state_mtz)
 #            self.mtz = mtztools(self.ground_state_mean_mtz)
 
     def run(self):

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -393,6 +393,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
         self.zenodo_dict = None
         self.pdb = None
         self.mtz = None
+        self.logDir = None
 
         self.ground_state = False
         self.ground_state_pdb = ''
@@ -404,6 +405,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
             self.ground_state_pdb = ground_state[0]
             self.ground_state_mtz = ground_state[1]
             self.panddaDir = ground_state[2]
+            self.logDir = self.projectDir
             self.projectDir = self.panddaDir
             self.pdb = pdbtools(self.ground_state_pdb)
             self.mtz = mtztools(self.ground_state_mtz)
@@ -857,7 +859,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
 
         if self.ground_state:
             refXtal = self.ground_state_pdb.split('/')[len(self.ground_state_pdb.split('/')) - 2]
-            aimless = os.path.join(self.projectDir,refXtal,refXtal+'.log')
+            aimless = os.path.join(self.logDir,refXtal,refXtal+'.log')
             self.Logfile.insert('aimless.log file: ' + aimless)
             Cmd = (pdb_extract_init +
                    ' -r {0!s}'.format(refSoft) +

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -857,6 +857,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
         if self.ground_state:
             refXtal = self.ground_state_pdb.split('/')[len(self.ground_state_pdb.split('/')) - 2]
             aimless = os.path.join(self.projectDir,refXtal,refXtal+'.log')
+            self.Logfile.insert('aimless.log file: ' + aimless)
             Cmd = (pdb_extract_init +
                    ' -r {0!s}'.format(refSoft) +
                    ' -iPDB {0!s}'.format(self.ground_state_pdb) +

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 18/02/2020                                                    #\n'
+            '     # Date: 20/02/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemToolTips.py
+++ b/lib/XChemToolTips.py
@@ -338,7 +338,7 @@ def deposition_ground_state_preparation_step_two_text():
 
 def deposition_ground_state_preparation_step_three_text():
     msg = (
-        '3. Please check the settings tab that you have selected the correct pandda directory.\n'
+        '1. Please check the settings tab that you have selected the correct pandda directory.\n'
         '   (Note: we will take all the apo mmcif files from this directory)\n'
         '   Current PanDDA directory:'
     )
@@ -346,13 +346,13 @@ def deposition_ground_state_preparation_step_three_text():
 
 def deposition_ground_state_preparation_step_four_text():
     msg = (
-        '4. Add the ground-state entry to the database.'
+        '2. Add the ground-state entry to the database.'
     )
     return msg
 
 def deposition_ground_state_preparation_step_five_text():
     msg = (
-            '5. Enter meta-data for ground-state model:\n'
+            '3. Enter meta-data for ground-state model:\n'
             '     - Open "Deposition -> Edit information"\n'
             '     - Fill out form or load .deposit file\n'
             '     - Press "Save to Database"\n'
@@ -362,21 +362,21 @@ def deposition_ground_state_preparation_step_five_text():
 
 def deposition_ground_state_preparation_step_six_text():
     msg = (
-            '6. Prepare the ground-state mmcif file.\n'
+            '4. Prepare the ground-state mmcif file.\n'
             '     Note: the mmcif files are saved into the selected pandda directory'
     )
     return msg
 
 def deposition_ground_state_preparation_step_seven_text():
     msg = (
-        '7. Press the button below to copy the structire and structure factor mmcif files into the "group deposition directory" (see settings tab).\n'
+        '5. Press the button below to copy the structire and structure factor mmcif files into the "group deposition directory" (see settings tab).\n'
         'Both mmcif files will be bundled into a single, bzipped tar archive which can be uploaded into via the PDB group deposition website.'
     )
     return msg
 
 def deposition_ground_state_preparation_step_eight_text():
     msg = (
-        '8. Go to the group deposition website, create a session and upload the ligand-bound.tar.bz2 file from the group deposition directory.'
+        '6. Go to the group deposition website, create a session and upload the ligand-bound.tar.bz2 file from the group deposition directory.'
     )
     return msg
 
@@ -424,5 +424,21 @@ def second_cif_file_not_exists():
         'The CIF file for the non-standard ligand does not exist! '
         'It was either not selected or the file was deleted/ moved in the meantime. '
         'Please check Menu -> Preferences.'
+    )
+    return msg
+
+def notification_about_changes_to_apo_deposition():
+    msg = (
+        'The ground-state deposition procedure has changes in XCE v1.5.0!\n\n'
+        'Previously, users had to select a specific reference PDB file, which had to have a ground-state mean-map and logfile associated with it.\n'
+        'However, there were two main problems: (i) the map to mtz conversion did sometimes lead to strange maps or maps in space group P1 only\n'
+        'and (2) occasionally the resulting MTZ files had missing columns. This lead to errors and delays during deposition, while inclusion of\n'
+        'ground-state mean maps has little benefit since the mean map can be calculated with the deposited apo datasets. Hence, there is really\n'
+        'no need to include it in the deposition.\n\n'
+        'All you need to do is to select the relevant PanDDA directory and XCE will arbitrarily select a high resolution structure with low Rfree\n'
+        'as the model for the deposition bundle and then put all structure factor MMCIF files into a single file. Note that it does not matter\n'
+        'which PDB file gets chosen at this point since the positional modifications during refinement with REFMAC will be minimal.\n'
+        'If you still want to make the ground-state mean map available, we would recommend to deposit ground-state mean map and \n'
+        'everything else you think is relevant on ZENODO and ask the PDB annotator to include the respective DOI in the deposition\n'
     )
     return msg

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -856,7 +856,7 @@ class parse:
 
 
     def calc_unitcell_volume_from_logfile(self,a,b,c,alpha,beta,gamma,lattice):
-        print '>>>',a,b,c,alpha,beta,gamma,lattice
+#        print '>>>',a,b,c,alpha,beta,gamma,lattice
         unitcell_volume=0
         if lattice=='triclinic':
             unitcell_volume=a*b*c* \


### PR DESCRIPTION
- ground-state mean maps are EXCLUDED from apo deposition, because either map2mtz conversion was faulty or columns were missing; moreover, they are not required to reproduce the maps and users can deposit them separately on ZENODO if they want