### PR TITLE
v1.5.3 (26/02/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.5.3 (26/02/2020)
+- bug fix: read spacegroup as H32 from xia2.mmcif ('R 3 2 :H')
+
 v1.5.2 (25/02/2020)
 - bug fix: correct determination of staraniso runs for different space groups
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.5.2'
+        xce_object.xce_version = 'v1.5.3'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 25/02/2020                                                    #\n'
+            '     # Date: 26/02/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -824,6 +824,10 @@ class parse:
                 self.aimless['DataCollectionWavelength'] = line.split()[1]
             elif line.startswith('_symmetry.space_group_name_H-M'):
                 self.aimless['DataProcessingSpaceGroup'] = line[line.find("'")+1:line.rfind("'")].replace(' ','')
+                if 'R32:H' in self.aimless['DataProcessingSpaceGroup']:
+                    self.aimless['DataProcessingSpaceGroup'] = 'H32'
+                if 'R3:H' in self.aimless['DataProcessingSpaceGroup']:
+                    self.aimless['DataProcessingSpaceGroup'] = 'H3'
                 self.aimless['DataProcessingPointGroup'] = self.get_pointgroup_from_space_group(
                     self.aimless['DataProcessingSpaceGroup'])
             elif line.startswith('_space_group.crystal_system'):


### PR DESCRIPTION
- bug fix: read spacegroup as H32 from xia2.mmcif ('R 3 2 :H')