### PR TITLE
v1.6.10 (04/05/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.6.10 (04/05/2020) 
+- bug fix: only read (2)fofc_twin.map during dimple_twin map review
+
 v1.6.9 (04/05/2020) 
 - added COOT command to open dimple_twin maps
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.6.9'
+        xce_object.xce_version = 'v1.6.10'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemCootTwin.py
+++ b/lib/XChemCootTwin.py
@@ -1255,12 +1255,12 @@ class GUI(object):
         # read fofc maps
         # - read ccp4 map: 0 - 2fofc map, 1 - fofc.map
         # read 2fofc map last so that one can change its contour level
-        if os.path.isfile(os.path.join(self.project_directory, self.xtalID, '2fofc.map')):
+        if os.path.isfile(os.path.join(self.project_directory, self.xtalID, '2fofc_twin.map')):
             coot.set_colour_map_rotation_on_read_pdb(0)
             coot.set_default_initial_contour_level_for_difference_map(3)
-            coot.handle_read_ccp4_map(os.path.join(self.project_directory, self.xtalID, 'fofc.map'), 1)
+            coot.handle_read_ccp4_map(os.path.join(self.project_directory, self.xtalID, 'fofc_twin.map'), 1)
             coot.set_default_initial_contour_level_for_map(1)
-            coot.handle_read_ccp4_map(os.path.join(self.project_directory, self.xtalID, '2fofc.map'), 0)
+            coot.handle_read_ccp4_map(os.path.join(self.project_directory, self.xtalID, '2fofc_twin.map'), 0)
             coot.set_last_map_colour(0, 0, 1)
         else:
             # try to open mtz file with same name as pdb file


### PR DESCRIPTION
- bug fix: only read (2)fofc_twin.map during dimple_twin map review