### PR TITLE
v1.6.13 (10/05/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.6.13 (10/05/2020)
+- XChemDeposit: use RefinementMMCIFmodel_latest (if available) instead of refine.split.bound-state.pdb
+
 v1.6.12 (09/05/2020)
 - capture refinement mmcif file location in DB after refinement (if available)
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.6.12'
+        xce_object.xce_version = 'v1.6.13'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -870,14 +870,25 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
                    ' -iENT data_template.cif'
                    ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
         else:
-            Cmd = (pdb_extract_init +
-                   ' -r {0!s}'.format(refSoft) +
-                   ' -iPDB {0!s}'.format('refine.split.bound-state.pdb') +
-                   ' -e MR'
-                   ' -s AIMLESS'
-                   ' -iLOG {0!s}.log'.format(xtal) +
-                   ' -iENT data_template.cif'
-                   ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
+            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+                self.Logfile.insert('%s: found MMCIF file; will use instead of PDB: %s' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
+                Cmd = (pdb_extract_init +
+                       ' -r {0!s}'.format(refSoft) +
+                       ' -iCIF {0!s}'.format(self.db_dict['RefinementMMCIFmodel_latest']) +
+                       ' -e MR'
+                       ' -s AIMLESS'
+                       ' -iLOG {0!s}.log'.format(xtal) +
+                       ' -iENT data_template.cif'
+                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
+            else:
+                Cmd = (pdb_extract_init +
+                       ' -r {0!s}'.format(refSoft) +
+                       ' -iPDB {0!s}'.format('refine.split.bound-state.pdb') +
+                       ' -e MR'
+                       ' -s AIMLESS'
+                       ' -iLOG {0!s}.log'.format(xtal) +
+                       ' -iENT data_template.cif'
+                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
 
         self.Logfile.insert(xtal + ': running pdb_extract: ' + Cmd)
         os.system(Cmd)

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 09/05/2020                                                    #\n'
+            '     # Date: 10/05/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'


### PR DESCRIPTION
- XChemDeposit: use RefinementMMCIFmodel_latest (if available) instead of refine.split.bound-state.pdb