### PR TITLE
v1.6.14 (11/05/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 v1.6.14 (11/05/2020)
+- XChemDeposit: usage of model mmcif file disabled because of unclear errors during group deposition
 - XChemDeposit: do not add ligand cif to model mmcif because Buster does already include it
 - XChemDeposit: use pdb_extract v3.26 when using mmcif instead of pdb files
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,6 @@
 v1.6.14 (11/05/2020)
 - XChemDeposit: do not add ligand cif to model mmcif because Buster does already include it
+- XChemDeposit: use pdb_extract v3.26 when using mmcif instead of pdb files
 
 v1.6.13 (10/05/2020)
 - XChemDeposit: use RefinementMMCIFmodel_latest (if available) instead of refine.split.bound-state.pdb

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 v1.6.14 (11/05/2020)
+- XChemUtils: get BUSTER from PROGRAM REMARK
 - XChemDeposit: usage of model mmcif file disabled because of unclear errors during group deposition
 - XChemDeposit: do not add ligand cif to model mmcif because Buster does already include it
 - XChemDeposit: use pdb_extract v3.26 when using mmcif instead of pdb files

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.6.14 (11/05/2020)
+- XChemDeposit: do not add ligand cif to model mmcif because Buster does already include it
+
 v1.6.13 (10/05/2020)
 - XChemDeposit: use RefinementMMCIFmodel_latest (if available) instead of refine.split.bound-state.pdb
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.6.13'
+        xce_object.xce_version = 'v1.6.14'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -993,18 +993,22 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
         filestatus = False
         self.Logfile.insert('%s: looking for ligand restraints file...' %xtal)
         os.chdir(os.path.join(self.projectDir, xtal))
-        if os.path.isfile(self.db_dict['CompoundCode']+'.cif'):
-            self.Logfile.insert('%s: found ligand restraints file -> %s' %(xtal,self.db_dict['CompoundCode']+'.cif'))
-            self.Logfile.insert('%s: adding ligand restraints file to model mmcif' %xtal)
-            cif = ''
-            for line in open(self.db_dict['CompoundCode']+'.cif'):
-                cif += line
-            f = open(xtal+'.mmcif','a')
-            f.write(cif)
-            f.close()
+        if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+            self.Logfile.insert('%s: found %s; assuming that ligand cif dictionary is already included...' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
             filestatus = True
         else:
-            self.Logfile.warning('%s: could not find %s' %(xtal,self.db_dict['CompoundCode']+'.cif'))
+            if os.path.isfile(self.db_dict['CompoundCode']+'.cif'):
+                self.Logfile.insert('%s: found ligand restraints file -> %s' %(xtal,self.db_dict['CompoundCode']+'.cif'))
+                self.Logfile.insert('%s: adding ligand restraints file to model mmcif' %xtal)
+                cif = ''
+                for line in open(self.db_dict['CompoundCode']+'.cif'):
+                    cif += line
+                f = open(xtal+'.mmcif','a')
+                f.write(cif)
+                f.close()
+                filestatus = True
+            else:
+                self.Logfile.warning('%s: could not find %s' %(xtal,self.db_dict['CompoundCode']+'.cif'))
         return filestatus
 
 

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -849,12 +849,12 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
         refSoft = self.pdb.get_refinement_program()
 
         if os.path.isdir('/dls'):
-#            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
-#                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/setup.sh\n'
-#                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/bin/pdb_extract'
-#            else:
-            pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
-            pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
+            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/setup.sh\n'
+                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/bin/pdb_extract'
+            else:
+                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
+                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
         else:
             pdb_extract_init = 'source ' + os.path.join(os.getenv('XChemExplorer_DIR'),
                                                         'pdb_extract/pdb-extract-prod/setup.sh') + '\n'
@@ -874,18 +874,18 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
                    ' -iENT data_template.cif'
                    ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
         else:
-#            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
-#                self.Logfile.insert('%s: found MMCIF file; will use instead of PDB: %s' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
-#                Cmd = (pdb_extract_init +
-#                       ' -r {0!s}'.format(refSoft) +
-#                       ' -iCIF {0!s}'.format(self.db_dict['RefinementMMCIFmodel_latest']) +
-#                       ' -e MR'
-#                       ' -s AIMLESS'
-#                       ' -iLOG {0!s}.log'.format(xtal) +
-#                       ' -iENT data_template.cif'
-#                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
- #           else:
-            Cmd = (pdb_extract_init +
+            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+                self.Logfile.insert('%s: found MMCIF file; will use instead of PDB: %s' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
+                Cmd = (pdb_extract_init +
+                       ' -r {0!s}'.format(refSoft) +
+                       ' -iCIF {0!s}'.format(self.db_dict['RefinementMMCIFmodel_latest']) +
+                       ' -e MR'
+                       ' -s AIMLESS'
+                       ' -iLOG {0!s}.log'.format(xtal) +
+                       ' -iENT data_template.cif'
+                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
+            else:
+                Cmd = (pdb_extract_init +
                        ' -r {0!s}'.format(refSoft) +
                        ' -iPDB {0!s}'.format('refine.split.bound-state.pdb') +
                        ' -e MR'

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -849,12 +849,12 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
         refSoft = self.pdb.get_refinement_program()
 
         if os.path.isdir('/dls'):
-            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
-                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/setup.sh\n'
-                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/bin/pdb_extract'
-            else:
-                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
-                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
+#            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+#                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/setup.sh\n'
+#                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/bin/pdb_extract'
+#            else:
+            pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
+            pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
         else:
             pdb_extract_init = 'source ' + os.path.join(os.getenv('XChemExplorer_DIR'),
                                                         'pdb_extract/pdb-extract-prod/setup.sh') + '\n'
@@ -874,18 +874,18 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
                    ' -iENT data_template.cif'
                    ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
         else:
-            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
-                self.Logfile.insert('%s: found MMCIF file; will use instead of PDB: %s' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
-                Cmd = (pdb_extract_init +
-                       ' -r {0!s}'.format(refSoft) +
-                       ' -iCIF {0!s}'.format(self.db_dict['RefinementMMCIFmodel_latest']) +
-                       ' -e MR'
-                       ' -s AIMLESS'
-                       ' -iLOG {0!s}.log'.format(xtal) +
-                       ' -iENT data_template.cif'
-                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
-            else:
-                Cmd = (pdb_extract_init +
+#            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+#                self.Logfile.insert('%s: found MMCIF file; will use instead of PDB: %s' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
+#                Cmd = (pdb_extract_init +
+#                       ' -r {0!s}'.format(refSoft) +
+#                       ' -iCIF {0!s}'.format(self.db_dict['RefinementMMCIFmodel_latest']) +
+#                       ' -e MR'
+#                       ' -s AIMLESS'
+#                       ' -iLOG {0!s}.log'.format(xtal) +
+#                       ' -iENT data_template.cif'
+#                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
+ #           else:
+            Cmd = (pdb_extract_init +
                        ' -r {0!s}'.format(refSoft) +
                        ' -iPDB {0!s}'.format('refine.split.bound-state.pdb') +
                        ' -e MR'

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -849,12 +849,12 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
         refSoft = self.pdb.get_refinement_program()
 
         if os.path.isdir('/dls'):
-            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
-                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/setup.sh\n'
-                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/bin/pdb_extract'
-            else:
-                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
-                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
+#            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+#                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/setup.sh\n'
+#                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/bin/pdb_extract'
+#            else:
+            pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
+            pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
         else:
             pdb_extract_init = 'source ' + os.path.join(os.getenv('XChemExplorer_DIR'),
                                                         'pdb_extract/pdb-extract-prod/setup.sh') + '\n'
@@ -874,18 +874,18 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
                    ' -iENT data_template.cif'
                    ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
         else:
-            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
-                self.Logfile.insert('%s: found MMCIF file; will use instead of PDB: %s' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
-                Cmd = (pdb_extract_init +
-                       ' -r {0!s}'.format(refSoft) +
-                       ' -iCIF {0!s}'.format(self.db_dict['RefinementMMCIFmodel_latest']) +
-                       ' -e MR'
-                       ' -s AIMLESS'
-                       ' -iLOG {0!s}.log'.format(xtal) +
-                       ' -iENT data_template.cif'
-                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
-            else:
-                Cmd = (pdb_extract_init +
+#            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+#                self.Logfile.insert('%s: found MMCIF file; will use instead of PDB: %s' %(xtal,self.db_dict['RefinementMMCIFmodel_latest']))
+#                Cmd = (pdb_extract_init +
+#                       ' -r {0!s}'.format(refSoft) +
+#                       ' -iCIF {0!s}'.format(self.db_dict['RefinementMMCIFmodel_latest']) +
+#                       ' -e MR'
+#                       ' -s AIMLESS'
+#                       ' -iLOG {0!s}.log'.format(xtal) +
+#                       ' -iENT data_template.cif'
+#                       ' -o {0!s}.mmcif > {1!s}.mmcif.log'.format(xtal, xtal))
+#            else:
+            Cmd = (pdb_extract_init +
                        ' -r {0!s}'.format(refSoft) +
                        ' -iPDB {0!s}'.format('refine.split.bound-state.pdb') +
                        ' -e MR'

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -849,8 +849,12 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
         refSoft = self.pdb.get_refinement_program()
 
         if os.path.isdir('/dls'):
-            pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
-            pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
+            if os.path.isfile(self.db_dict['RefinementMMCIFmodel_latest']):
+                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/setup.sh\n'
+                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-v3.26/pdb-extract-v3.26-prod-src/bin/pdb_extract'
+            else:
+                pdb_extract_init = 'source /dls/science/groups/i04-1/software/pdb-extract-prod/setup.sh\n'
+                pdb_extract_init += '/dls/science/groups/i04-1/software/pdb-extract-prod/bin/pdb_extract'
         else:
             pdb_extract_init = 'source ' + os.path.join(os.getenv('XChemExplorer_DIR'),
                                                         'pdb_extract/pdb-extract-prod/setup.sh') + '\n'

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 10/05/2020                                                    #\n'
+            '     # Date: 11/05/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -1828,6 +1828,8 @@ class pdbtools(object):
                     program = 'REFMAC'
                 elif 'phenix' in remark.lower():
                     program = 'PHENIX'
+                elif 'buster' in remark.lower():
+                    program = 'BUSTER'
         return  program
 
     def get_residues_with_resname(self,resname):


### PR DESCRIPTION
- XChemUtils: get BUSTER from PROGRAM REMARK
- XChemDeposit: usage of model mmcif file disabled because of unclear errors during group deposition
- XChemDeposit: do not add ligand cif to model mmcif because Buster does already include it
- XChemDeposit: use pdb_extract v3.26 when using mmcif instead of pdb files