### PR TITLE
v1.6.17 (17/05/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.6.17 (17/05/2020)
+- DIMPLE: added 'tolerance 5' keyword to pointless step to allow reindexing in case of slightly larger unit cell differences
+
 v1.6.16 (12/05/2020)
 - XChemExplorer.py removed unused 'import gtk' statement which is incompatible with ccp4 7.1
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.6.16'
+        xce_object.xce_version = 'v1.6.17'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 12/05/2020                                                    #\n'
+            '     # Date: 17/05/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemThread.py
+++ b/lib/XChemThread.py
@@ -1783,7 +1783,9 @@ class run_dimple_on_all_autoprocessing_files_new(QtCore.QThread):
                 ' resolution file 1 999.0 %s\n' %str(round(float(mtzFile.d_min()),2))+
                 'eof\n'
                 '\n'
-                'pointless hklin %s.999A.mtz hklout %s.999A.reind.mtz xyzin %s > pointless.reind.log\n' %(xtal,xtal,ref_pdb) +
+                'pointless hklin %s.999A.mtz hklout %s.999A.reind.mtz xyzin %s << eof > pointless.reind.log\n' %(xtal,xtal,ref_pdb) +
+                ' tolerance 5\n'
+                'eof\n'
                 '\n'
                 "dimple --no-cleanup %s.999A.reind.mtz %s %s %s %s dimple%s\n" % (xtal, ref_pdb, ref_mtz, ref_cif, twinRefmac, twin) +
                 '\n'


### PR DESCRIPTION
- DIMPLE: added 'tolerance 5' keyword to pointless step to allow reindexing in case of slightly larger unit cell differences