### PR TITLE
v1.6.24 (22/06/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.6.24 (22/06/2020)
+- bug fix: missing '\n' in calculate_maps (XChemRefine) deleted soakDB file
+
 v1.6.23 (12/06/2020)
 - use gemmi (if available) to convert event maps to mtz
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.6.23'
+        xce_object.xce_version = 'v1.6.24'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 12/06/2020                                                    #\n'
+            '     # Date: 22/06/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -504,7 +504,8 @@ class Refine(object):
             ' border 5\n'
             'EOF\n'
             '\n'
-            '/bin/rm fofc_asu.map'
+            '/bin/rm fofc_asu.map\n'
+            '\n'
         )
         return cmd
 


### PR DESCRIPTION
- bug fix: missing '\n' in calculate_maps (XChemRefine) deleted soakDB file