### PR TITLE
v1.7.5 (21/07/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.5 (21/07/2020)
+- bug fix: remove obsolete 'module load mx' statement from xce_<restraints_prg> script which currently loads a gemmi incompatible ccp4 version
+
 v1.7.4 (21/07/2020)
 - bug fix: selected results not linked after parsing of auto-processing results
 - enabled updates of message & progress bar during scoring of auto-processing results

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.4'
+        xce_object.xce_version = 'v1.7.5'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -274,9 +274,9 @@ class helpers:
 
         strip_hydrogens = 'phenix.reduce {0!s}.pdb -trim > {0!s}_tmp.pdb'.format(compoundID.replace(' ', ''))
 
-        module = ''
-        if os.path.isdir('/dls'):
-            module = 'module load mx\n'
+#        module = ''
+#        if os.path.isdir('/dls'):
+#            module = 'module load mx\n'
 
         Cmds = (
 
@@ -284,9 +284,9 @@ class helpers:
             '\n'
             'export XChemExplorer_DIR="' + os.getenv('XChemExplorer_DIR') + '"' +
             '\n'
-            'source $XChemExplorer_DIR/setup-scripts/xce.setup-sh'
-            '\n'
-            + module +
+#            'source $XChemExplorer_DIR/setup-scripts/xce.setup-sh'
+#            '\n'
+#            + module +
             '\n'
             '$CCP4/bin/ccp4-python $XChemExplorer_DIR/helpers/update_status_flag.py {0!s} {1!s} {2!s} {3!s}'
             .format(os.path.join(database_directory, data_source_file), sample, 'RefinementCIFStatus', 'running') +


### PR DESCRIPTION
 - bug fix: remove obsolete 'module load mx' statement from xce_<restraints_prg> script which currently loads a gemmi incompatible ccp4 version