### PR TITLE
v1.7.6 (22/07/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.6 (22/07/2020)
+- bug fix: added 'module load ccp4/phenix' to restraints script in case not part of user bashrc file
+
 v1.7.5 (21/07/2020)
 - bug fix: remove obsolete 'module load mx' statement from xce_<restraints_prg> script which currently loads a gemmi incompatible ccp4 version
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.5'
+        xce_object.xce_version = 'v1.7.6'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 21/07/2020                                                    #\n'
+            '     # Date: 22/07/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemUtils.py
+++ b/lib/XChemUtils.py
@@ -239,11 +239,15 @@ class helpers:
 
         software=''
         if restraints_program=='acedrg':
+            if os.getcwd().startswith('/dls'):
+                software += 'module load ccp4\n'
             if os.path.isfile(os.path.join(initial_model_directory,sample,'old.cif')):
                 software='acedrg --res LIG -c ../old.cif -o {0!s}\n'.format((compoundID.replace(' ','')))
             else:
                 software='acedrg --res LIG -i "{0!s}" -o {1!s}\n'.format(productSmiles, compoundID.replace(' ',''))
         elif restraints_program=='phenix.elbow':
+            if os.getcwd().startswith('/dls'):
+                software += 'module load phenix\n'
             if os.path.isfile(os.path.join(initial_model_directory,sample,'old.cif')):
                 software='phenix.elbow --file=../old.cif --id LIG --output {0!s}\n'.format((compoundID.replace(' ','')))
             else:


### PR DESCRIPTION
- bug fix: added 'module load ccp4/phenix' to restraints script in case not part of user bashrc file