### PR TITLE
v1.7.9 (03/09/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.9 (03/09/2020)
+- change 'Open COOT' to 'Open COOT - REFMAC refinement -' in Refinement action box
+
 v1.7.8 (01/09/2020)
 - bug fix: string formatting error during restraints generation on local machine
 - added scanchirals option to rhofit command in fit_ligands function

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -3550,6 +3550,8 @@ class XChemExplorer(QtGui.QApplication):
                 self.update_log.insert('starting coot...')
                 if instruction == "Open COOT":
                     interface = 'new'
+                elif instruction == "Open COOT - REFMAC refinement -":
+                    interface = 'new'
                 elif instruction == "Open COOT - test -":
                     interface = 'test'
                 elif instruction == "Open COOT for old PanDDA":

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.8'
+        xce_object.xce_version = 'v1.7.9'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12
@@ -647,8 +647,8 @@ class setup():
                                          'pre-run for ground state model',
                                          'Build ground state model']
 
-        xce_object.refine_file_tasks = ['Open COOT',
-                                        'Open COOT - BUSTER refinement -',
+        xce_object.refine_file_tasks = ['Open COOT - BUSTER refinement -',
+                                        'Open COOT - REFMAC refinement -',
                                         'Open COOT - dimple_twin -' ]
 
 #        xce_object.refine_file_tasks = ['Open COOT',

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 01/09/2020                                                    #\n'
+            '     # Date: 03/09/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'


### PR DESCRIPTION
- change 'Open COOT' to 'Open COOT - REFMAC refinement -' in Refinement action box