### PR TITLE
v1.7.10 (08/09/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.10 (08/09/2020)
+- bug fix - preparation of mmcif files for deposition: enable usage of event mtz files which were generated during 'BUSTER' export routine
+
 v1.7.9 (03/09/2020)
 - change 'Open COOT' to 'Open COOT - REFMAC refinement -' in Refinement action box
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.9'
+        xce_object.xce_version = 'v1.7.10'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -709,8 +709,8 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
             ligCC = []
 
             # for newer BUSTER export
-            print '>>>> %s-event_*.native_%s.mtz' %(xtal,lig)
-            for mtz in glob.glob(('%s-event_*.native_%s.mtz' %(xtal,lig))):
+            print '>>>> %s-event_*.native_%s.mtz' %(xtal,lig.replace('.pdb',''))
+            for mtz in glob.glob(('%s-event_*.native_%s.mtz' %(xtal,lig.replace('.pdb','')))):
                 self.Logfile.insert(xtal + ': found ' + mtz)
                 foundMatchingMap = True
                 self.eventList.append(mtz)

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -700,6 +700,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
             self.Logfile.warning('%s: found empty file named "no_pandda_analysis_performed" which suggests we will ignore event maps for this sample' %xtal)
             foundMatchingMap = True
             ligList = []
+
         for lig in sorted(ligList):
             ligID = lig.replace('.pdb','')
 #            if os.path.isfile('no_pandda_analysis_performed'):
@@ -714,6 +715,9 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
                 self.Logfile.insert(xtal + ': found ' + mtz)
                 foundMatchingMap = True
                 self.eventList.append(mtz)
+                break
+
+            if foundMatchingMap:
                 continue
 
             for mtz in sorted(glob.glob('*event*.native*P1.mtz')):

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -707,6 +707,14 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
 #                foundMatchingMap = True
 #                break
             ligCC = []
+
+            # for newer BUSTER export
+            for mtz in glob.glob(('%s-event_*.native_%s.mtz' %(xtal,lig))):
+                self.Logfile.insert(xtal + ': found ' + mtz)
+                foundMatchingMap = True
+                self.eventList.append(mtz)
+                continue
+
             for mtz in sorted(glob.glob('*event*.native*P1.mtz')):
                 self.get_lig_cc(xtal, mtz, lig)
                 cc = self.check_lig_cc(mtz.replace('.mtz', '_CC'+ligID+'.log'))

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -709,6 +709,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
             ligCC = []
 
             # for newer BUSTER export
+            print '>>>> %s-event_*.native_%s.mtz' %(xtal,lig)
             for mtz in glob.glob(('%s-event_*.native_%s.mtz' %(xtal,lig))):
                 self.Logfile.insert(xtal + ': found ' + mtz)
                 foundMatchingMap = True

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 03/09/2020                                                    #\n'
+            '     # Date: 08/09/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'


### PR DESCRIPTION
- bug fix - preparation of mmcif files for deposition: enable usage of event mtz files which were generated during 'BUSTER' export routine