### PR TITLE
v1.7.13 (23/09/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.13 (23/09/2020)
+- bug fix: use wavelength read from (.free).mtz during model MMCIF preparation when updating SF MMCIF
+
 v1.7.12 (14/09/2020)
 - bug fix: problem with recognizing AIMLESS logfiles during preparation of MMCIF files
 - bug fix: try finding experimental wavelength from .free.mtz file if it is 0.0 in refine.mtz during MMCIF file preparation

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.12'
+        xce_object.xce_version = 'v1.7.13'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemDeposit.py
+++ b/lib/XChemDeposit.py
@@ -1302,7 +1302,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
 
         block = -1
 
-        self.Logfile.insert('%s: reading wavelength from mtz file; lambda = %s' %(xtal,self.mtz.get_wavelength()))
+        self.Logfile.insert('%s: reading wavelength from mtz file; lambda = %s' %(xtal,str(self.data_template_dict['radiation_wavelengths'])))
 
         if os.path.isfile('no_pandda_analysis_performed'):
             self.Logfile.warning('%s: apparently not a pandda deposition; will skip this step...' %xtal)
@@ -1324,7 +1324,7 @@ class prepare_mmcif_files_for_deposition(QtCore.QThread):
                             '_diffrn.details             "%s"\n' % bound[n]).replace('$',str(block-1))
                 sys.stdout.write(newLines)
             elif line.startswith('_diffrn_radiation_wavelength.wavelength'):
-                sys.stdout.write('_diffrn_radiation_wavelength.wavelength   {0!s}\n'.format(self.mtz.get_wavelength()))
+                sys.stdout.write('_diffrn_radiation_wavelength.wavelength   {0!s}\n'.format(str(self.data_template_dict['radiation_wavelengths'])))
             else:
                 sys.stdout.write(line)
 

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 14/09/2020                                                    #\n'
+            '     # Date: 23/09/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'


### PR DESCRIPTION
- bug fix: use wavelength read from (.free).mtz during model MMCIF preparation when updating SF MMCIF