### PR TITLE
v1.7.14 (24/09/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.14 (24/09/2020)
+- added option for ligand occupancy refinement in BUSTER
+
 v1.7.13 (23/09/2020)
 - bug fix: use wavelength read from (.free).mtz during model MMCIF preparation when updating SF MMCIF
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,6 @@
 v1.7.14 (24/09/2020)
 - added option for ligand occupancy refinement in BUSTER
+- XChemCootBuster: reading of (2)fofc.maps disabled because Coot 0.9 does not handle P1 maps well
 
 v1.7.13 (23/09/2020)
 - bug fix: use wavelength read from (.free).mtz during model MMCIF preparation when updating SF MMCIF

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.13'
+        xce_object.xce_version = 'v1.7.14'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemCootBuster.py
+++ b/lib/XChemCootBuster.py
@@ -1452,10 +1452,8 @@ class GUI(object):
                 foundPDB = True
                 break
         if foundPDB:
-            print '>>>'
             coot.write_pdb_file(item, os.path.join(self.project_directory, self.xtalID, 'cootOut',
                                                            'Refine_' + str(self.Serial), 'in.pdb'))
-            print '>>>>>>'
 
 #            self.Refine.RunRefmac(self.Serial, self.RefmacParams, self.external_software, self.xce_logfile, self.covLinkAtomSpec)
             self.Refine.RunBuster(self.Serial, self.RefmacParams, self.external_software, self.xce_logfile, self.covLinkAtomSpec)

--- a/lib/XChemCootBuster.py
+++ b/lib/XChemCootBuster.py
@@ -174,7 +174,8 @@ class GUI(object):
                              'TLS': '',
                              'NCS': '',
                              'TWIN': '',
-                             'WATER':   ''  }
+                             'WATER':   '',
+                             'LIGOCC':  ''  }
 
     def StartGUI(self):
 

--- a/lib/XChemCootBuster.py
+++ b/lib/XChemCootBuster.py
@@ -1452,8 +1452,10 @@ class GUI(object):
                 foundPDB = True
                 break
         if foundPDB:
+            print '>>>'
             coot.write_pdb_file(item, os.path.join(self.project_directory, self.xtalID, 'cootOut',
                                                            'Refine_' + str(self.Serial), 'in.pdb'))
+            print '>>>>>>'
 
 #            self.Refine.RunRefmac(self.Serial, self.RefmacParams, self.external_software, self.xce_logfile, self.covLinkAtomSpec)
             self.Refine.RunBuster(self.Serial, self.RefmacParams, self.external_software, self.xce_logfile, self.covLinkAtomSpec)

--- a/lib/XChemCootBuster.py
+++ b/lib/XChemCootBuster.py
@@ -1264,7 +1264,10 @@ class GUI(object):
         # read fofc maps
         # - read ccp4 map: 0 - 2fofc map, 1 - fofc.map
         # read 2fofc map last so that one can change its contour level
-        if os.path.isfile(os.path.join(self.project_directory, self.xtalID, '2fofc.map')):
+#        if os.path.isfile(os.path.join(self.project_directory, self.xtalID, '2fofc.map')):
+        # coot 0.9 does not handle P1 maps well, so now looking for non-existent map in order to trigger
+        # map calculation from mtz file
+        if os.path.isfile(os.path.join(self.project_directory, self.xtalID, '2fofc_??????.map')):
             coot.set_colour_map_rotation_on_read_pdb(0)
             coot.set_default_initial_contour_level_for_difference_map(3)
             coot.handle_read_ccp4_map(os.path.join(self.project_directory, self.xtalID, 'fofc.map'), 1)
@@ -1273,7 +1276,8 @@ class GUI(object):
             coot.set_last_map_colour(0, 0, 1)
         else:
             # try to open mtz file with same name as pdb file
-            coot.set_default_initial_contour_level_for_map(1)
+#            coot.set_default_initial_contour_level_for_map(1)
+            coot.set_colour_map_rotation_on_read_pdb(0)
             #            if not os.path.isfile(os.path.join(self.project_directory,self.xtalID,self.mtz_style)):
             #                os.chdir(os.path.join(self.project_directory,self.xtalID))
             #                if not os.path.isfile('REFINEMENT_IN_PROGRESS'):

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 23/09/2020                                                    #\n'
+            '     # Date: 24/09/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -592,6 +592,8 @@ class Refine(object):
 
     def RunBuster(self,Serial,RefmacParams,external_software,xce_logfile,covLinkAtomSpec):
 
+        print '>>>>>>>'
+
         if RefmacParams == None:
             anisotropic_Bfactor = ' -M ADP '
             update_water = ''

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -625,21 +625,16 @@ class Refine(object):
 
         hklin, hklout = self.get_hklin_hklout(Serial)
 
-        refine_ligand_occupancy = ''
-        if RefmacParams != None:
-            if 'LIGOCC' in RefmacParams['LIGOCC']:
-                print 'JJJJJJJJ'
-                print hklin
-                ligand_info = pdbtools(hklin).get_residues_with_resname('LIG')
-                print 'GGGGGGGG'
-                if self.prepare_gelly_dat(ligand_info):
-                    refine_ligand_occupancy = ' -B user gelly.dat '
-
-
-
         resh, resl = mtztools_gemmi(hklin).get_high_low_resolution_limits()
 
         xyzin, xyzout = self.get_xyzin_xyzout(Serial)
+
+        refine_ligand_occupancy = ''
+        if RefmacParams != None:
+            if 'LIGOCC' in RefmacParams['LIGOCC']:
+                ligand_info = pdbtools(xyzin).get_residues_with_resname('LIG')
+                if self.prepare_gelly_dat(ligand_info):
+                    refine_ligand_occupancy = ' -B user gelly.dat '
 
         libin, libout = self.get_libin_libout(Serial)
 

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -592,8 +592,6 @@ class Refine(object):
 
     def RunBuster(self,Serial,RefmacParams,external_software,xce_logfile,covLinkAtomSpec):
 
-        print '>>>>>>>'
-
         if RefmacParams == None:
             anisotropic_Bfactor = ' -M ADP '
             update_water = ''
@@ -634,7 +632,7 @@ class Refine(object):
             if 'LIGOCC' in RefmacParams['LIGOCC']:
                 ligand_info = pdbtools(xyzin).get_residues_with_resname('LIG')
                 if self.prepare_gelly_dat(ligand_info):
-                    refine_ligand_occupancy = ' -B user gelly.dat '
+                    refine_ligand_occupancy = ' -B user -Gelly gelly.dat '
 
         libin, libout = self.get_libin_libout(Serial)
 

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -670,19 +670,23 @@ class Refine(object):
 
     def prepare_gelly_dat(self,ligand_info):
         found_ligand = False
-        gelly = ''
-        for lig in ligand_info:
+        gelly = 'NOTE BUSTER_SET Ligand = '
+        for n,lig in enumarate(ligand_info):
             resseq = lig[1]
             chain = lig[2]
+            if n == 0:
+                gelly += '{ %s|%s }' %(chain.replace(' ',''),resseq.replace(' ',''))
+            else:
+                gelly += ' + { %s|%s }' %(chain.replace(' ',''),resseq.replace(' ',''))
+            found_ligand = True
+        if '{' in gelly:
+            gelly += '\n'
             gelly += (
-                'NOTE BUSTER_SET Ligand = { %s|%s }\n' %(chain.replace(' ',''),resseq.replace(' ','')) +
                 'NOTE BUSTER_SET NotLigand = \ Ligand\n'
                 'NOTE BUSTER_CONSTANT OCC NotLigand \n'
                 'NOTE BUSTER_COMBINE OCC Ligand \n'
                 'NOTE BUSTER_COMBINE B Ligand      \n'
                 )
-            found_ligand = True
-        if gelly != '':
             os.chdir(os.path.join(self.ProjectPath,self.xtalID))
             f = open('gelly.dat','w')
             f.write(gelly)

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -116,6 +116,11 @@ class RefineParams(object):
         if self.RefmacParams['WATER']=='WATER\n': self.WATER.set_active(True)
         self.vbox.pack_start(self.WATER,False)
 
+        self.LIGOCC = gtk.CheckButton('Refine ligand occupancy (BUSTER)')
+        self.LIGOCC.connect("toggled", self.LIGOCCCallback)
+        if self.RefmacParams['LIGOCC']=='LIGOCC\n': self.LIGOCC.set_active(True)
+        self.vbox.pack_start(self.LIGOCC,False)
+
         self.OKbutton = gtk.Button(label="OK")
         self.OKbutton.connect("clicked",self.OK)
         self.vbox.add(self.OKbutton)
@@ -175,6 +180,13 @@ class RefineParams(object):
             self.RefmacParams['WATER']=''
         return self.RefmacParams
 
+    def LIGOCCCallback(self, widget):
+        if widget.get_active():
+            self.RefmacParams['LIGOCC']='LIGOCC\n'
+        else:
+            self.RefmacParams['LIGOCC']=''
+        return self.RefmacParams
+
     def OK(self,widget):
         self.window.destroy()
 
@@ -192,7 +204,8 @@ class RefineParams(object):
                        'TLS':    '',
                        'NCS':    '',
                        'TWIN':   '',
-                       'WATER':  '' }
+                       'WATER':  '',
+                       'LIGOCC': '' }
 
         if os.path.isfile(self.ProjectPath+'/'+self.xtalID+'/Refine_'+str(Serial)+'/refmac.csh'):
             for line in open(self.ProjectPath+'/'+self.xtalID+'/Refine_'+str(Serial)+'/refmac.csh'):
@@ -426,14 +439,14 @@ class Refine(object):
                  + self.datasource + ' ' + self.xtalID + ' RefinementStatus running\n')
         return cmd
 
-    def add_buster_command(self,cmd,xyzin,hklin,libin,Serial,anisotropic_Bfactor,update_water):
+    def add_buster_command(self,cmd,xyzin,hklin,libin,Serial,anisotropic_Bfactor,update_water,refine_ligand_occupancy):
         cmd += (
             'refine '
             ' -p %s' %xyzin +
             ' -m %s' %hklin +
             ' -l %s' %libin +
             ' -autoncs'
-            + anisotropic_Bfactor + update_water +
+            + anisotropic_Bfactor + update_water + refine_ligand_occupancy +
             ' -d Refine_%s\n' %str(Serial)
         )
         return cmd
@@ -593,6 +606,7 @@ class Refine(object):
             else:
                 update_water = ''
 
+
         self.error = False
 
         if os.path.isfile(xce_logfile):
@@ -608,6 +622,15 @@ class Refine(object):
             return None
 
         hklin, hklout = self.get_hklin_hklout(Serial)
+
+        refine_ligand_occupancy = ''
+        if RefmacParams != None:
+            if 'LIGOCC' in RefmacParams['LIGOCC']:
+                ligand_info = pdbtools(hklin).get_residues_with_resname('LIG')
+                if self.prepare_gelly_dat(ligand_info):
+                    refine_ligand_occupancy = ' -B user gelly.dat '
+
+
 
         resh, resl = mtztools_gemmi(hklin).get_high_low_resolution_limits()
 
@@ -627,7 +650,7 @@ class Refine(object):
 
         cmd = self.set_refinement_status(cmd)
 
-        cmd = self.add_buster_command(cmd,xyzin,hklin,libin,Serial,anisotropic_Bfactor,update_water)
+        cmd = self.add_buster_command(cmd,xyzin,hklin,libin,Serial,anisotropic_Bfactor,update_water,refine_ligand_occupancy)
 
         cmd = self.add_validation(cmd,Serial,'buster')
 
@@ -646,6 +669,28 @@ class Refine(object):
             self.write_refinement_script(cmd,'buster')
             self.Logfile.insert('%s: starting refinement...' %self.xtalID)
             self.run_script('buster',external_software)
+
+    def prepare_gelly_dat(self,ligand_info):
+        found_ligand = False
+        gelly = ''
+        for lig in ligand_info:
+            resseq = lig[1]
+            chain = lig[2]
+            gelly += (
+                'NOTE BUSTER_SET Ligand = { %s|%s }\n' %(chain,resseq) +
+                'NOTE BUSTER_SET NotLigand = \ Ligand\n'
+                'NOTE BUSTER_CONSTANT OCC NotLigand \n'
+                'NOTE BUSTER_COMBINE OCC Ligand \n'
+                'NOTE BUSTER_COMBINE B Ligand      \n'
+                )
+            found_ligand = True
+        if gelly != '':
+            os.chdir(self.ProjectPath,self.xtalID)
+            f = open('gelly.dat','w')
+            f.write(gelly)
+            f.close()
+        return found_ligand
+
 
     def RunRefmac(self,Serial,RefmacParams,external_software,xce_logfile,covLinkAtomSpec):
 

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -1065,7 +1065,8 @@ class Refine(object):
                        'TLS':    '',
                        'NCS':    '',
                        'TWIN':   '',
-                       'WATER':  ''     }
+                       'WATER':  '',
+                       'LIGOCC':    ''  }
 
         if os.path.isfile(self.ProjectPath+'/'+self.xtalID+'/Refine_'+str(Serial)+'/refmac.csh'):
             for line in open(self.ProjectPath+'/'+self.xtalID+'/Refine_'+str(Serial)+'/refmac.csh'):

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -675,7 +675,7 @@ class Refine(object):
             resseq = lig[1]
             chain = lig[2]
             gelly += (
-                'NOTE BUSTER_SET Ligand = { %s|%s }\n' %(chain,resseq) +
+                'NOTE BUSTER_SET Ligand = { %s|%s }\n' %(chain.replace(' ',''),resseq.replace(' ','')) +
                 'NOTE BUSTER_SET NotLigand = \ Ligand\n'
                 'NOTE BUSTER_CONSTANT OCC NotLigand \n'
                 'NOTE BUSTER_COMBINE OCC Ligand \n'

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -685,7 +685,7 @@ class Refine(object):
                 )
             found_ligand = True
         if gelly != '':
-            os.chdir(self.ProjectPath,self.xtalID)
+            os.chdir(os.path.join(self.ProjectPath,self.xtalID))
             f = open('gelly.dat','w')
             f.write(gelly)
             f.close()

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -628,7 +628,9 @@ class Refine(object):
         refine_ligand_occupancy = ''
         if RefmacParams != None:
             if 'LIGOCC' in RefmacParams['LIGOCC']:
+                print 'JJJJJJJJ'
                 ligand_info = pdbtools(hklin).get_residues_with_resname('LIG')
+                print 'GGGGGGGG'
                 if self.prepare_gelly_dat(ligand_info):
                     refine_ligand_occupancy = ' -B user gelly.dat '
 

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -671,7 +671,7 @@ class Refine(object):
     def prepare_gelly_dat(self,ligand_info):
         found_ligand = False
         gelly = 'NOTE BUSTER_SET Ligand = '
-        for n,lig in enumarate(ligand_info):
+        for n,lig in enumerate(ligand_info):
             resseq = lig[1]
             chain = lig[2]
             if n == 0:

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -629,6 +629,7 @@ class Refine(object):
         if RefmacParams != None:
             if 'LIGOCC' in RefmacParams['LIGOCC']:
                 print 'JJJJJJJJ'
+                print hklin
                 ligand_info = pdbtools(hklin).get_residues_with_resname('LIG')
                 print 'GGGGGGGG'
                 if self.prepare_gelly_dat(ligand_info):


### PR DESCRIPTION
- added option for ligand occupancy refinement in BUSTER
- XChemCootBuster: reading of (2)fofc.maps disabled because Coot 0.9 does not handle P1 maps well