### PR TITLE
v1.7.16 (08/10/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,8 @@
-v1.7.16 (25/09/2020)
+v1.7.16 (08/10/2020)
 - enable export of selected datasets with pandda.export
 - glitch fix: remove hydrogens before saving model for buster refinement (causes problems during ligand occupancy refinement)
+- XChemRefine: removed "-q medium.q" option for non-DLS refinement
+- added helper script to which reverts to last successful non-pandda refinement
 
 v1.7.15 (25/09/2020)
 - added option to ignore GELLY sanity check in BUSTER

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@ v1.7.16 (08/10/2020)
 - XChemRefine: removed "-q medium.q" option for non-DLS refinement
 - added helper script to which reverts to last successful non-pandda refinement
 - XChemCoot (pandda refinement): reading of (2)fofc.maps disabled because Coot 0.9 does not handle P1 maps well
+- pandda.analyse: stopped sourcing obsolete pandda v0.2.12 at DLS
 
 v1.7.15 (25/09/2020)
 - added option to ignore GELLY sanity check in BUSTER

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.16 (25/09/2020)
+- enable export of selected datasets with pandda.export
+
 v1.7.15 (25/09/2020)
 - added option to ignore GELLY sanity check in BUSTER
 - added option to ignore GELLY sanity check during pandda export with BUSTER

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,6 +3,7 @@ v1.7.16 (08/10/2020)
 - glitch fix: remove hydrogens before saving model for buster refinement (causes problems during ligand occupancy refinement)
 - XChemRefine: removed "-q medium.q" option for non-DLS refinement
 - added helper script to which reverts to last successful non-pandda refinement
+- XChemCoot (pandda refinement): reading of (2)fofc.maps disabled because Coot 0.9 does not handle P1 maps well
 
 v1.7.15 (25/09/2020)
 - added option to ignore GELLY sanity check in BUSTER

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,6 @@
 v1.7.16 (25/09/2020)
 - enable export of selected datasets with pandda.export
+- glitch fix: remove hydrogens before saving model for buster refinement (causes problems during ligand occupancy refinement)
 
 v1.7.15 (25/09/2020)
 - added option to ignore GELLY sanity check in BUSTER

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -3516,6 +3516,11 @@ class XChemExplorer(QtGui.QApplication):
             which_models = 'all'
             self.run_pandda_export(update_datasource_only, which_models)
 
+        elif instruction == 'Export SELECTED PANDDA models':
+            update_datasource_only = False
+            which_models = 'selected'
+            self.run_pandda_export(update_datasource_only, which_models)
+
         elif instruction == 'refine ALL bound-state models with BUSTER':
             self.run_refine_bound_state_with_buster('all')
 
@@ -3799,6 +3804,31 @@ class XChemExplorer(QtGui.QApplication):
         self.work_thread.start()
 
     def run_pandda_export(self, update_datasource_only, which_models):
+
+        pandda_params = {
+            'data_dir': str(self.pandda_input_data_dir_entry.text()),
+            'out_dir': str(self.pandda_output_data_dir_entry.text()),
+            'submit_mode': str(self.pandda_submission_mode_selection_combobox.currentText()),
+            'nproc': str(self.pandda_nproc_entry.text()),
+            'min_build_datasets': str(self.pandda_min_build_dataset_entry.text()),
+            'pdb_style': str(self.pandda_pdb_style_entry.text()),
+            'mtz_style': str(self.pandda_mtz_style_entry.text()),
+            'sort_event': str(self.pandda_sort_event_combobox.currentText()),
+            'average_map': str(self.pandda_calc_map_combobox.currentText()),
+            'max_new_datasets': str(self.pandda_max_new_datasets_entry.text()),
+            'grid_spacing': str(self.pandda_grid_spacing_entry.text()),
+            'pandda_dir_structure': str(self.pandda_input_data_dir_entry.text()),
+            'perform_diffraction_data_scaling': str(self.wilson_checkbox.isChecked()),
+            'filter_pdb': str(self.pandda_reference_file_selection_combobox.currentText()),
+            'reference_dir': self.reference_directory,
+            'appendix': '',
+            'N_datasets': len(glob.glob(os.path.join(self.initial_model_directory, '*', 'dimple.pdb'))),
+            'write_mean_map': 'interesting',
+            'pandda_table': self.pandda_analyse_data_table,
+            'use_remote': self.using_remote_qsub_submission,
+            'remote_string': self.remote_qsub_submission
+        }
+
         self.settings['panddas_directory'] = str(self.pandda_output_data_dir_entry.text())
         if update_datasource_only:
             self.update_log.insert('updating data source with results from pandda.inspect')
@@ -3831,7 +3861,7 @@ class XChemExplorer(QtGui.QApplication):
                                                              os.path.join(self.database_directory,
                                                                           self.data_source_file),
                                                              self.initial_model_directory, self.xce_logfile,
-                                                             update_datasource_only, which_models)
+                                                             update_datasource_only, which_models, pandda_params)
             self.connect(self.work_thread, QtCore.SIGNAL("finished()"), self.thread_finished)
             self.work_thread.start()
 
@@ -5124,9 +5154,10 @@ class XChemExplorer(QtGui.QApplication):
 
     def kill_other_pandda_options(self):
         for i in range(0, self.pandda_analyse_data_table.rowCount()):
-            checkbox1 = self.pandda_analyse_data_table.cellWidget(i,6)
-            checkbox2 = self.pandda_analyse_data_table.cellWidget(i,7)
-            checkbox3 = self.pandda_analyse_data_table.cellWidget(i,8)
+            checkbox0 = self.pandda_analyse_data_table.cellWidget(i,1)
+            checkbox1 = self.pandda_analyse_data_table.cellWidget(i,7)
+            checkbox2 = self.pandda_analyse_data_table.cellWidget(i,8)
+            checkbox3 = self.pandda_analyse_data_table.cellWidget(i,9)
             if checkbox1.isChecked():
                 checkbox2.setChecked(False)
                 checkbox3.setChecked(False)

--- a/XChemExplorer.py
+++ b/XChemExplorer.py
@@ -5195,6 +5195,11 @@ class XChemExplorer(QtGui.QApplication):
                         deselect_button.stateChanged.connect(self.kill_other_pandda_options)
                         self.pandda_analyse_data_table.setCellWidget(current_row, column, deselect_button)
 
+                    elif header[0]=='Export':
+                        deselect_button = QtGui.QCheckBox()
+                        deselect_button.stateChanged.connect(self.kill_other_pandda_options)
+                        self.pandda_analyse_data_table.setCellWidget(current_row, column, deselect_button)
+
                     elif header[0] == 'Sample ID':
                         cell_text = QtGui.QTableWidgetItem()
                         cell_text.setText(str(xtal))

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.15'
+        xce_object.xce_version = 'v1.7.16'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12
@@ -386,6 +386,7 @@ class setup():
 
         xce_object.pandda_table_columns = [
                                            'Sample ID',
+                                           'Export\nSelected',
                                            'Refinement\nSpace Group',
                                            'Resolution\n[Mn<I/sig(I)> = 1.5]',
                                            'Dimple\nRcryst',
@@ -633,8 +634,11 @@ class setup():
         xce_object.panddas_file_tasks = ['pandda.analyse',
                                          'pandda.inspect',
                                          'run pandda.inspect at home',
+                                         '------------------------------------------',
                                          'Export NEW PANDDA models',
                                          'Export ALL PANDDA models',
+                                         'Export SELECTED PANDDA models',
+                                         '------------------------------------------',
                                          'Show HTML summary',
 #                                         'Update datasource with results from pandda.inspect',
                                          'cluster datasets',

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -658,7 +658,10 @@ class setup():
 
         xce_object.refine_file_tasks = ['Open COOT - BUSTER refinement -',
                                         'Open COOT - REFMAC refinement -',
-                                        'Open COOT - dimple_twin -' ]
+                                        'Open COOT - dimple_twin -',
+#                                        '-------------------------------',
+#                                        'Reset to last successful refinement (BUSTER or REFMAC)',
+                                        '']
 
 #        xce_object.refine_file_tasks = ['Open COOT',
 #                                        'Open COOT for old PanDDA',

--- a/helpers/reset_to_last_successful_refinement.py
+++ b/helpers/reset_to_last_successful_refinement.py
@@ -1,0 +1,55 @@
+import os,glob
+import sys
+
+def find_refine_folder(projectDir):
+    for xtalDir in sorted(glob.glob(os.path.join(projectDir,'*'))):
+        xtal = xtalDir[xtalDir.rfind('/')+1:]
+        os.chdir(xtalDir)
+        dirList = []
+        for dirs in sorted(glob.glob('*')):
+            if dirs.startswith('Refine_') and os.path.isdir(dirs):
+                if not os.path.isfile('refine.pdb'):
+                    dirList.append([dirs,os.path.getctime(dirs)])
+        if dirList != []:
+            find_refine_pdb(xtal, dirList)
+
+def find_refine_pdb(xtal, dirList):
+    sorted_list = sorted(dirList, key=lambda x: x[1], reverse = True)
+    foundRefinePDB = False
+    for d in sorted_list:
+        serial = int(d[0].split('_')[1])
+        if os.path.isfile(os.path.join(d[0],'refine.pdb')):
+            print xtal + ': found refine.pdb in ' + d[0]
+            pdbLink = os.path.join(d[0],'refine.pdb')
+            mtzLink = os.path.join(d[0],'refine.mtz')
+            foundRefinePDB = True
+            break
+        elif os.path.isfile(os.path.join(d[0],'refine_%s.pdb' %str(serial))):
+            print xtal + ': found refine_%s.pdb in %s' %(str(serial),d[0])
+            foundRefinePDB = True
+            pdbLink = os.path.join(d[0],'refine_%s.pdb' %str(serial))
+            mtzLink = os.path.join(d[0],'refine_%s.mtz' %str(serial))
+            break
+    if not foundRefinePDB:
+        print xtal + ': ERROR -> cannot find refine.pdb'
+    else:
+        print os.getcwd(),pdbLink, mtzLink
+        reset_links(xtal, pdbLink, mtzLink)
+
+def find_pandda_refine_pdb(xtal, dirList):
+    print 'hallp'
+
+def reset_links(xtal, pdbLink, mtzLink):
+    print xtal + ': resetting links...'
+    os.system('/bin/rm refine.pdb')
+    os.system('/bin/rm refine.mtz')
+    os.system('/bin/rm refine.split.bound-state.pdb')
+    os.system('ln -s %s refine.pdb' %pdbLink)
+    os.system('ln -s %s refine.mtz' %mtzLink)
+    os.system('ln -s refine.pdb refine.split.bound-state.pdb')
+
+
+
+if __name__ == '__main__':
+    projectDir = sys.argv[1]
+    find_refine_folder(projectDir)

--- a/lib/XChemCootBuster.py
+++ b/lib/XChemCootBuster.py
@@ -1456,6 +1456,7 @@ class GUI(object):
                 foundPDB = True
                 break
         if foundPDB:
+            coot.delete_hydrogens(item)
             coot.write_pdb_file(item, os.path.join(self.project_directory, self.xtalID, 'cootOut',
                                                            'Refine_' + str(self.Serial), 'in.pdb'))
 

--- a/lib/XChemCootNew.py
+++ b/lib/XChemCootNew.py
@@ -1373,6 +1373,14 @@ class GUI(object):
         #
 
         #######################################################
+
+#        #######################################################
+#        # create folder for new refinement cycle and check if free.mtz exists
+#        if not os.path.isdir(os.path.join(self.project_directory, self.xtalID)):
+#            os.mkdir(os.path.join(self.project_directory, self.xtalID))
+#        if not os.path.isdir(os.path.join(self.project_directory, self.xtalID, 'Refine_' + str(self.Serial))):
+#            os.mkdir(os.path.join(self.project_directory, self.xtalID, 'Refine_' + str(self.Serial)))
+
         if self.refinementProtocol.startswith('pandda'):
 
             #######################################################

--- a/lib/XChemCootNew.py
+++ b/lib/XChemCootNew.py
@@ -1259,7 +1259,9 @@ class GUI(object):
         # read fofc maps
         # - read ccp4 map: 0 - 2fofc map, 1 - fofc.map
         # read 2fofc map last so that one can change its contour level
-        if os.path.isfile(os.path.join(self.project_directory, self.xtalID, '2fofc.map')):
+        # coot 0.9 does not handle P1 maps well, so now looking for non-existent map in order to trigger
+        # map calculation from mtz file
+        if os.path.isfile(os.path.join(self.project_directory, self.xtalID, '2fofc_??????.map')):
             coot.set_colour_map_rotation_on_read_pdb(0)
             coot.set_default_initial_contour_level_for_difference_map(3)
             coot.handle_read_ccp4_map(os.path.join(self.project_directory, self.xtalID, 'fofc.map'), 1)

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -1441,7 +1441,7 @@ class data_source:
 #                continue
             if item.startswith('Export'):
 #                out_list.append('Export')
-                out_list.append([item,item])
+                out_list.append(['Export',item])
                 continue
             if item.startswith('Show'):
                 out_list.append([item,item])

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -1440,7 +1440,8 @@ class data_source:
 #                out_list.append([item,item])
 #                continue
             if item.startswith('Export'):
-                out_list.append('Export')
+#                out_list.append('Export')
+                out_list.append([item,item])
                 continue
             if item.startswith('Show'):
                 out_list.append([item,item])

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -1439,6 +1439,9 @@ class data_source:
 #            if item.startswith('img'):
 #                out_list.append([item,item])
 #                continue
+            if item.startswith('Export'):
+                out_list.append([item,item])
+                continue
             if item.startswith('Show'):
                 out_list.append([item,item])
                 continue

--- a/lib/XChemDB.py
+++ b/lib/XChemDB.py
@@ -1440,7 +1440,7 @@ class data_source:
 #                out_list.append([item,item])
 #                continue
             if item.startswith('Export'):
-                out_list.append([item,item])
+                out_list.append('Export')
                 continue
             if item.startswith('Show'):
                 out_list.append([item,item])

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 25/09/2020                                                    #\n'
+            '     # Date: 08/10/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemPANDDA.py
+++ b/lib/XChemPANDDA.py
@@ -747,6 +747,13 @@ class run_pandda_export(QtCore.QThread):
             if self.which_models=='all':
                 self.Logfile.insert('exporting '+sample)
                 samples_to_export[sample]=fileModelsDict[sample]
+            elif self.which_models == 'selected':
+                for i in range(0, self.pandda_analyse_data_table.rowCount()):
+                    if str(self.pandda_analyse_data_table.item(i, 0).text()) == sample:
+                        if self.pandda_analyse_data_table.cellWidget(i, 1).isChecked():
+                            self.Logfile.insert('Dataset selected by user -> exporting '+sample)
+                            samples_to_export[sample]=fileModelsDict[sample]
+                            break
             else:
                 if sample in dbModelsDict:
                     try:

--- a/lib/XChemPANDDA.py
+++ b/lib/XChemPANDDA.py
@@ -907,7 +907,9 @@ class run_pandda_analyse(QtCore.QThread):
 #            else:
 #                source_file=''
             # v1.2.1 - pandda.setup files should be obsolete now that pandda is part of ccp4
-            source_file='source /dls/science/groups/i04-1/software/pandda_0.2.12/ccp4/ccp4-7.0/bin/ccp4.setup-sh\n'
+            # 08/10/2020 - pandda v0.2.12 installation at DLS is obsolete
+#            source_file='source /dls/science/groups/i04-1/software/pandda_0.2.12/ccp4/ccp4-7.0/bin/ccp4.setup-sh\n'
+            source_file = ''
             source_file += 'export XChemExplorer_DIR="' + os.getenv('XChemExplorer_DIR') + '"\n'
 
             if os.path.isfile(self.filter_pdb + '.pdb'):

--- a/lib/XChemPANDDA.py
+++ b/lib/XChemPANDDA.py
@@ -487,7 +487,7 @@ class refine_bound_state_with_buster(QtCore.QThread):
 
 class run_pandda_export(QtCore.QThread):
 
-    def __init__(self,panddas_directory,datasource,initial_model_directory,xce_logfile,update_datasource_only,which_models):
+    def __init__(self,panddas_directory,datasource,initial_model_directory,xce_logfile,update_datasource_only,which_models,pandda_params):
         QtCore.QThread.__init__(self)
         self.panddas_directory=panddas_directory
         self.datasource=datasource
@@ -501,6 +501,7 @@ class run_pandda_export(QtCore.QThread):
         self.update_datasource_only=update_datasource_only
         self.which_models=which_models
         self.already_exported_models=[]
+        self.pandda_analyse_data_table = pandda_params['pandda_table']
 
         self.RefmacParams={ 'HKLIN':            '',                 'HKLOUT': '',
                             'XYZIN':            '',                 'XYZOUT': '',

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -588,9 +588,12 @@ class Refine(object):
 
     def run_script(self,program,external_software):
         os.chdir(os.path.join(self.ProjectPath,self.xtalID))
-        if external_software['qsub'] and not os.uname()[1] == 'hestia':
+        if external_software['qsub'] and os.path.isdir('/dls'):
             self.Logfile.insert('starting refinement with command: qsub -P labxchem -q medium.q %s.sh' %program)
             os.system("qsub -P labxchem -q medium.q %s.sh" %program)
+        elif external_software['qsub'] and not os.path.isdir('/dls'):
+            self.Logfile.insert('starting refinement with command: qsub %s.sh' %program)
+            os.system("qsub %s.sh" %program)
         elif external_software['qsub_remote'] != '':
             Logfile.insert('starting refinement on remote cluster')
             remote_command=external_software['qsub_remote'].replace('qsub','cd %s; qsub' %os.path.join(self.ProjectPath,self.xtalID,'cootOut','Refine_'+str(Serial)))
@@ -950,10 +953,12 @@ class Refine(object):
             os.system("%s -P labxchem -q medium.q refmac.csh'" %remote_command)
             print '%s -P labxchem -q medium.q refmac.csh' %remote_command
 
-        elif external_software['qsub'] and not os.uname()[1] == 'hestia':
-            Logfile.insert('starting refinement on cluster')
+        elif external_software['qsub'] and os.path.isdir('/dls'):
+            Logfile.insert('starting refinement on cluster with command "qsub -P labxchem -q medium.q refmac.csh"')
             os.system("qsub -P labxchem -q medium.q refmac.csh")
-
+        elif external_software['qsub'] and not os.path.isdir('/dls'):
+            Logfile.insert('starting refinement on cluster with command "qsub refmac.csh"')
+            os.system("qsub refmac.csh")
         else:
             os.system('chmod +x refmac.csh')
             if os.path.isfile(xce_logfile): Logfile.insert('starting refinement on local machine')
@@ -1495,7 +1500,7 @@ class panddaRefine(object):
             + module_load +
             '\n'
             +source+
-            'cd '+self.ProjectPath+'/'+self.xtalID+'\n'
+            'cd '+self.ProjectPath+'/'+self.xtalID+'/Refine_'+Serial+'\n'
             '\n'
             '$CCP4/bin/ccp4-python $XChemExplorer_DIR/helpers/update_status_flag.py %s %s %s %s\n' %(self.datasource,self.xtalID,'RefinementStatus','running') +
             '\n'
@@ -1510,7 +1515,7 @@ class panddaRefine(object):
             " split_conformations='False'"
             '\n'
             'cd '+self.ProjectPath+'/'+self.xtalID+'/Refine_'+str(panddaSerial)+'\n'
-            
+            '\n'
             'ln -s '+self.ProjectPath+'/'+self.xtalID+'/Refine_'+str(panddaSerial)+'/refine_'+str(Serial)+'_001.pdb '
             +self.ProjectPath+'/'+self.xtalID+'/Refine_'+str(panddaSerial)+'/refine_'+str(Serial)+'.pdb' +'\n'
              


### PR DESCRIPTION
- enable export of selected datasets with pandda.export
- glitch fix: remove hydrogens before saving model for buster refinement (causes problems during ligand occupancy refinement)
- XChemRefine: removed "-q medium.q" option for non-DLS refinement
- added helper script to which reverts to last successful non-pandda refinement
- XChemCoot (pandda refinement): reading of (2)fofc.maps disabled because Coot 0.9 does not handle P1 maps well
- pandda.analyse: stopped sourcing obsolete pandda v0.2.12 at DLS