### PR TITLE
v1.7.18 (12/10/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.18 (12/10/2020)
+- bug fix: added missing 'module load ccp4' statement when generating pandda.analyse shell script at DLS
+
 v1.7.17 (09/10/2020)
 - bug fix: corrected positions of ignore checkboxes in pandda.analyse
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.17'
+        xce_object.xce_version = 'v1.7.18'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 09/10/2020                                                    #\n'
+            '     # Date: 12/10/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemPANDDA.py
+++ b/lib/XChemPANDDA.py
@@ -938,7 +938,11 @@ class run_pandda_analyse(QtCore.QThread):
             if self.data_directory.startswith('/dls'):
                 dls = (
                     source_file +
-                    '\n' + 'module load pymol/1.8.2.0' + ' \n'
+                    '\n'
+                    'module load pymol/1.8.2.0\n'
+                    '\n'
+                    'module load ccp4\n'
+                    '\n'
                 )
 
             Cmds = (


### PR DESCRIPTION
- bug fix: added missing 'module load ccp4' statement when generating pandda.analyse shell script at DLS