### PR TITLE
v1.7.19 (12/10/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.19 (12/10/2020)
+- bug fix: use 'module load ccp4/7.0.072' for pandda.analyse, but 'module load ccp4' (i.e. v7.1) for pre-run ground-state selection at DLS
+
 v1.7.18 (12/10/2020)
 - bug fix: added missing 'module load ccp4' statement when generating pandda.analyse shell script at DLS
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.18'
+        xce_object.xce_version = 'v1.7.19'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemPANDDA.py
+++ b/lib/XChemPANDDA.py
@@ -861,7 +861,9 @@ class run_pandda_analyse(QtCore.QThread):
             if os.path.isdir(self.panddas_directory):
                 os.system('/bin/rm -fr %s' %self.panddas_directory)
             os.mkdir(self.panddas_directory)
-            self.select_ground_state_model='$CCP4/bin/ccp4-python %s %s\n' %(os.path.join(os.getenv('XChemExplorer_DIR'),'helpers','select_ground_state_dataset.py'),self.panddas_directory)
+            if self.data_directory.startswith('/dls'):
+                self.select_ground_state_model = 'module load ccp4\n'
+            self.select_ground_state_model +='$CCP4/bin/ccp4-python %s %s\n' %(os.path.join(os.getenv('XChemExplorer_DIR'),'helpers','select_ground_state_dataset.py'),self.panddas_directory)
             self.make_ligand_links=''
 
     def run(self):
@@ -941,7 +943,7 @@ class run_pandda_analyse(QtCore.QThread):
                     '\n'
                     'module load pymol/1.8.2.0\n'
                     '\n'
-                    'module load ccp4\n'
+                    'module load ccp4/7.0.072\n'
                     '\n'
                 )
 


### PR DESCRIPTION
- bug fix: use 'module load ccp4/7.0.072' for pandda.analyse, but 'module load ccp4' (i.e. v7.1) for pre-run ground-state selection at DLS