### PR TITLE
v1.7.21 (19/10/2020)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.21 (19/10/2020)
+- bug fix: use default CCP4 for giant.merge_conformations
+
 v1.7.20 (16/10/2020)
 - bug fix: remove undocumented and faulty changes to RunQuickRefine
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.20'
+        xce_object.xce_version = 'v1.7.21'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 16/10/2020                                                    #\n'
+            '     # Date: 19/10/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -1295,7 +1295,8 @@ class panddaRefine(object):
                 if os.getcwd().startswith('/dls'):
                     cmd = (
                     'export XChemExplorer_DIR="%s"\n' %os.getenv('XChemExplorer_DIR')+
-                    'source %s\n' %os.path.join(os.getenv('XChemExplorer_DIR'),'setup-scripts','pandda.setup-sh\n') +
+#                    'source %s\n' %os.path.join(os.getenv('XChemExplorer_DIR'),'setup-scripts','pandda.setup-sh\n') +
+                    'module load ccp4\n'
                     'giant.merge_conformations major=%s minor=%s reset_all_occupancies=False options.major_occupancy=1.0 options.minor_occupancy=1.0' %(ground_state,bound_state)
                     )
                 else:


### PR DESCRIPTION
- bug fix: use default CCP4 for giant.merge_conformations