### PR TITLE
v1.7.23 (02/11/2020) 

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v1.7.23 (02/11/2020)
+- pandda refinement: stopped sourcing obsolete pandda v0.2.12 at DLS (otherwise refinement update script fails due to missing gemmi library)
+
 v1.7.22 (28/10/2020)
 - cosmetic changes to deposition interface
 - bug fix: make event map assignment during MMCIF preparation backward compatible

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.7.22'
+        xce_object.xce_version = 'v1.7.23'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 28/10/2020                                                    #\n'
+            '     # Date: 02/11/2020                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, Structural Genomics Consortium, Oxford, UK  #\n'
             '     #          tobias.krojer@sgc.ox.ac.uk                                 #\n'

--- a/lib/XChemRefine.py
+++ b/lib/XChemRefine.py
@@ -1435,24 +1435,26 @@ class panddaRefine(object):
                 spider_plot+='giant.score_model pdb1=%s mtz1=%s pdb2=%s mtz2=%s res_names=LIG,UNL,DRG,FRG\n' %(pdb_one,mtz_one,pdb_two,mtz_two)
 
         #######################################################
-        # PHENIX stuff (if working at DLS)
+        # CCP4 & PHENIX stuff (if working at DLS)
         module_load=''
         if os.getcwd().startswith('/dls'):
-            module_load='module load phenix\n'
+            module_load = 'module load ccp4\n'
+            module_load += 'module load phenix\n'
 
         # 2017-07-20: for the time being this will explicitly source pandda since version 0.2 really only works at DLS
+        # 2020-11-02: will start using default ccp4 installation at DLS otherwise gemmi does not work
         source =''
         if 'bash' in os.getenv('SHELL'):
             source = (
                 'export XChemExplorer_DIR="'+os.getenv('XChemExplorer_DIR')+'"\n'
                 '\n'
-                'source %s\n' %os.path.join(os.getenv('XChemExplorer_DIR'),'setup-scripts','pandda.setup-sh\n')
+#                'source %s\n' %os.path.join(os.getenv('XChemExplorer_DIR'),'setup-scripts','pandda.setup-sh\n')
             )
         elif 'csh' in os.getenv('SHELL'):
             source = (
                 'setenv XChemExplorer_DIR '+os.getenv('XChemExplorer_DIR')+'\n'
                 '\n'
-                'source %s\n' %os.path.join(os.getenv('XChemExplorer_DIR'),'setup-scripts','pandda.setup-csh\n')
+#                'source %s\n' %os.path.join(os.getenv('XChemExplorer_DIR'),'setup-scripts','pandda.setup-csh\n')
             )
 
 


### PR DESCRIPTION
- pandda refinement: stopped sourcing obsolete pandda v0.2.12 at DLS (otherwise refinement update script fails due to missing gemmi library)