### PR TITLE
v1.9.2 (28/06/2022)  

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,7 @@
+v1.9.2 (28/06/2022)
+- replace obsolete 'source /dls/science/groups/i04-1/software/pandda-update/ccp4/ccp4-7.0/bin/ccp4.setup-sh' with 'module load ccp4/7.1.016' before running pandda.export
+
+
 v1.9.1 (16/06/2022)
 - changed add instances of 'module load ccp4' to 'module load ccp4/7.1.018', except for the pandda2 function
 

--- a/gui_scripts/settings_preferences.py
+++ b/gui_scripts/settings_preferences.py
@@ -30,7 +30,7 @@ class setup():
 
     def settings(self, xce_object):
         # set XCE version
-        xce_object.xce_version = 'v1.9.1'
+        xce_object.xce_version = 'v1.9.2'
 
         # general settings
         xce_object.allowed_unitcell_difference_percent = 12

--- a/lib/XChemLog.py
+++ b/lib/XChemLog.py
@@ -26,7 +26,7 @@ class startLog:
             '     #                                                                     #\n'
             '     # Version: %s                                       #\n' %pasteVersion+
             '     #                                                                     #\n'
-            '     # Date: 16/06/2022                                                    #\n'
+            '     # Date: 28/06/2022                                                    #\n'
             '     #                                                                     #\n'
             '     # Authors: Tobias Krojer, MAXIV Laboratory, SE                        #\n'
             '     #          tobias.krojer@maxiv.lu.se                                  #\n'

--- a/lib/XChemPANDDA.py
+++ b/lib/XChemPANDDA.py
@@ -804,7 +804,8 @@ class run_pandda_export(QtCore.QThread):
             else:
 
                 Cmds = (
-                    'source /dls/science/groups/i04-1/software/pandda-update/ccp4/ccp4-7.0/bin/ccp4.setup-sh\n'
+                    'module load ccp4/7.1.016\n'
+#                    'source /dls/science/groups/i04-1/software/pandda-update/ccp4/ccp4-7.0/bin/ccp4.setup-sh\n'
 #                    'source '+os.path.join(os.getenv('XChemExplorer_DIR'),'setup-scripts','pandda.setup-sh')+'\n'
                     'pandda.export'
                     ' pandda_dir=%s' %self.panddas_directory+


### PR DESCRIPTION
replace obsolete 'source /dls/science/groups/i04-1/software/pandda-update/ccp4/ccp4-7.0/bin/ccp4.setup-sh' with 'module load ccp4/7.1.016' before running pandda.export