### PR TITLE
set buster refmac tasks

### DIFF
--- a/xce/lib/XChemRefine.py
+++ b/xce/lib/XChemRefine.py
@@ -697,6 +697,7 @@ class Refine(object):
             "{!s}.sh".format(program),
             xce_logfile,
             slurm_token,
+            tasks=8,
         )
 
     def RunBuster(
@@ -1192,7 +1193,7 @@ class Refine(object):
             % (os.path.join(self.ProjectPath, self.xtalID, "Refine_" + Serial))
         )
 
-        slurm.submit_cluster_job("xce_refmac", "refmac.csh", xce_logfile, slurm_token)
+        slurm.submit_cluster_job("xce_refmac", "refmac.csh", xce_logfile, slurm_token, tasks=8)
 
     def RefinementParams(self, RefmacParams):
         self.RefmacParams = RefmacParams
@@ -2157,7 +2158,7 @@ class panddaRefine(object):
             )
         )
 
-        slurm.submit_cluster_job("refmac", "refmac.csh", xce_logfile, slurm_token)
+        slurm.submit_cluster_job("refmac", "refmac.csh", xce_logfile, slurm_token, tasks=8)
 
     def RefinementParams(self, RefmacParams):
         self.RefmacParams = RefmacParams

--- a/xce/lib/XChemRefine.py
+++ b/xce/lib/XChemRefine.py
@@ -1193,7 +1193,9 @@ class Refine(object):
             % (os.path.join(self.ProjectPath, self.xtalID, "Refine_" + Serial))
         )
 
-        slurm.submit_cluster_job("xce_refmac", "refmac.csh", xce_logfile, slurm_token, tasks=8)
+        slurm.submit_cluster_job(
+            "xce_refmac", "refmac.csh", xce_logfile, slurm_token, tasks=8
+        )
 
     def RefinementParams(self, RefmacParams):
         self.RefmacParams = RefmacParams
@@ -2158,7 +2160,9 @@ class panddaRefine(object):
             )
         )
 
-        slurm.submit_cluster_job("refmac", "refmac.csh", xce_logfile, slurm_token, tasks=8)
+        slurm.submit_cluster_job(
+            "refmac", "refmac.csh", xce_logfile, slurm_token, tasks=8
+        )
 
     def RefinementParams(self, RefmacParams):
         self.RefmacParams = RefmacParams


### PR DESCRIPTION
Increased `tasks` in `slurm.submit_cluster_job` for buster and refmac refinement jobs.  
Given that buster refine appears to use max 8 cores ([https://www.globalphasing.com/buster/manual/autobuster/manual/autoBUSTER4.html#:~:text=By%20default%2C%20the%20%22refine%22,refine%20argument%20%2Dnthreads%20is%20used](https://www.globalphasing.com/buster/manual/autobuster/manual/autoBUSTER4.html#:~:text=By%20default%2C%20the%20%22refine%22,refine%20argument%20%2Dnthreads%20is%20used)) requesting exclusive node access on these jobs would seem to be inefficient, so have opted for 8 cores for these jobs.