### PR TITLE
update mogul path to CSDS 2024

### DIFF
--- a/XChemExplorer_dls
+++ b/XChemExplorer_dls
@@ -4,7 +4,7 @@ module load buster/20240123
 module load phenix/1.20
 module load ccp4/7.1.018
 
-export BDG_TOOL_MOGUL="/dls_sw/apps/ccdc/CSD_2020/bin/mogul"
+export BDG_TOOL_MOGUL="/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul"
 export XChemExplorer_DIR=$(readlink -e $0 | xargs dirname)
 export LD_PRELOAD="/usr/lib64/libfreetype.so:${LD_PRELOAD}"
 

--- a/xce/lib/XChemRefine.py
+++ b/xce/lib/XChemRefine.py
@@ -603,7 +603,8 @@ class Refine(object):
                 )
                 buster_report += "cd " + self.ProjectPath + "/" + self.xtalID + "\n"
                 buster_report += (
-                    "export BDG_TOOL_MOGUL=/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
+                    "export BDG_TOOL_MOGUL="
+                    "/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
                 )
                 buster_report += "buster-report -d Refine_%s\n" % cycle
 

--- a/xce/lib/XChemRefine.py
+++ b/xce/lib/XChemRefine.py
@@ -603,7 +603,7 @@ class Refine(object):
                 )
                 buster_report += "cd " + self.ProjectPath + "/" + self.xtalID + "\n"
                 buster_report += (
-                    "export BDG_TOOL_MOGUL=/dls_sw/apps/ccdc/CSD_2020/bin/mogul\n"
+                    "export BDG_TOOL_MOGUL=/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
                 )
                 buster_report += "buster-report -d Refine_%s\n" % cycle
 

--- a/xce/lib/XChemUtils.py
+++ b/xce/lib/XChemUtils.py
@@ -86,7 +86,8 @@ class helpers:
                         software += "module load buster/20240123\n"
                         software += (
                             "export BDG_TOOL_MOGUL="
-                            "/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
+                            "/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul"
+                            "\n"
                         )
                     software += "export BDG_TOOL_OBABEL='none'\n"
 
@@ -184,7 +185,8 @@ class helpers:
                 software += "module load ccp4/7.1.018\n"
                 software += "module load buster/20240123\n"
                 software += (
-                    "export BDG_TOOL_MOGUL=/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
+                    "export BDG_TOOL_MOGUL="
+                    "/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
                 )
                 software += "export BDG_TOOL_OBABEL='none'\n"
                 if external_software["mogul"]:

--- a/xce/lib/XChemUtils.py
+++ b/xce/lib/XChemUtils.py
@@ -86,7 +86,7 @@ class helpers:
                         software += "module load buster/20240123\n"
                         software += (
                             "export BDG_TOOL_MOGUL="
-                            "/dls_sw/apps/ccdc/CSD_2020/bin/mogul\n"
+                            "/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
                         )
                     software += "export BDG_TOOL_OBABEL='none'\n"
 
@@ -184,7 +184,7 @@ class helpers:
                 software += "module load ccp4/7.1.018\n"
                 software += "module load buster/20240123\n"
                 software += (
-                    "export BDG_TOOL_MOGUL=/dls_sw/apps/ccdc/CSD_2020/bin/mogul\n"
+                    "export BDG_TOOL_MOGUL=/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul\n"
                 )
                 software += "export BDG_TOOL_OBABEL='none'\n"
                 if external_software["mogul"]:


### PR DESCRIPTION
it is likely that the existing mogul path `BDG_TOOL_MOGUL="/dls_sw/apps/ccdc/CSD_2020/bin/mogul` would be affected by the `module load ccdc` deprecation warning.

path updated to latest: `/dls_sw/apps/CSDS/2024.1.0/ccdc-software/mogul/bin/mogul`