### PR TITLE
Get buster-report working again

### DIFF
--- a/xce/lib/XChemRefine.py
+++ b/xce/lib/XChemRefine.py
@@ -516,6 +516,7 @@ class Refine(object):
         if os.getcwd().startswith("/dls"):
             cmd += "module load phenix/1.20\n"
             cmd += "module load buster/20240123\n"
+            cmd += "module load graphviz\n"
         return cmd
 
     def get_source_line(self, cmd):


### PR DESCRIPTION
`buster-report` has been failing due to the absence of graphviz libraries on the cluster nodes. These libraries have now been installed by scientific computing and can be accessed with `module load graphviz`. This command has been added to the preamble before `buster-report` is executed in xce.

I have tested `buster-report` on the cluster with some test data and the expected output files (report.pdf, index.html etc) are now successfully produced.